### PR TITLE
fix: player sprite hidden by tile layers after zone transition (#22)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -222,6 +222,10 @@ Bugs are tracked here alongside their GitHub issue. When a bug is reported:
 2. Add it to this section as ⏳
 3. Fix it, mark ✅ with commit hash, close the issue
 
+- ⏳ **Juan sprite hidden by tile layers after zone transition** [#22](https://github.com/m3ssana/swampfire/issues/22)
+  - Player depth defaults to 0; new tile layers added after transition sit above it in display list
+  - Fix: `setDepth(10)` on player sprite — always renders above ground (0) and obstacles (1)
+
 - ✅ **Loot item spawns inside wall/container body after searching** [#21](https://github.com/m3ssana/swampfire/issues/21) _(26b1acb)_
   - Item dropped at `container ± 30px` could land in adjacent tree/wall/water or inside the container's own physics body
   - Fix: drop at player's current position `± 10px` — player is always in passable space

--- a/src/gameobjects/player.js
+++ b/src/gameobjects/player.js
@@ -32,7 +32,8 @@ export default class Player {
     this.sprite
       .setExistingBody(mainBody)
       .setFixedRotation()
-      .setPosition(x, y);
+      .setPosition(x, y)
+      .setDepth(10); // Always render above tile layers (ground=0, obstacles=1)
 
     this.addEvents();
     this.addAnimations();


### PR DESCRIPTION
## Root Cause

On zone transition, `_buildTilemap()` adds new ground/obstacle layers to the display list *after* the existing player sprite. Since all three were at depth 0 (the Phaser default), the new ground layer sat on top of Juan — making him invisible.

## Fix

One-line change in `player.js` `init()`:

```js
this.sprite
  .setExistingBody(mainBody)
  .setFixedRotation()
  .setPosition(x, y)
  .setDepth(10); // Always render above tile layers (ground=0, obstacles=1)
```

`setDepth(10)` guarantees Juan renders above both tile layers in all zones, regardless of display-list insertion order.

## Test plan

- [ ] Juan visible on initial Zone 0 load (no regression)
- [ ] Walk south → zone transition → Juan visible in Zone 1
- [ ] Walk north → zone transition → Juan visible back in Zone 0
- [ ] Juan renders above ground tiles, not clipped by obstacle tiles

Closes #22
🤖 Generated with [Claude Code](https://claude.com/claude-code)