### PR TITLE
fix: zone transition lock never releases, blocking return trips (#24)

### DIFF
--- a/src/gameobjects/zone_manager.js
+++ b/src/gameobjects/zone_manager.js
@@ -39,8 +39,10 @@ const ZONES = {
     tileKey:     'swamp-tiles',
     tilesetName: 'swamp',
     entryPoints: {
-      // Arriving from Zone 1 (south exit) → appear near south trail, row 55
-      1: { x: 40 * 48, y: 55 * 48 },
+      // Arriving from Zone 1 (south exit) → appear on south trail, row 52.
+      // Row 55 (y=2640) was only 96px north of the south exit trigger (y=2736);
+      // row 52 (y=2496) gives comfortable clearance while still feeling southerly.
+      1: { x: 40 * 48, y: 52 * 48 },
       // Arriving from Zone 3 (west exit) → appear near west trail, col 4
       3: { x:  4 * 48, y: 30 * 48 },
     },
@@ -51,8 +53,11 @@ const ZONES = {
     tileKey:     'us41-tiles',
     tilesetName: 'us41',
     entryPoints: {
-      // Arriving from Zone 0 (north) → appear on highway just south of north corridor
-      0: { x: 40 * 48, y: 5 * 48 },
+      // Arriving from Zone 0 (north) → appear on highway, well south of north exit
+      // trigger (y=0–144). Row 5 (y=240) was only 96px from the trigger; row 12
+      // (y=576) gives comfortable clearance and drops the player into the main
+      // commercial area rather than right at the border fence.
+      0: { x: 40 * 48, y: 12 * 48 },
       // Arriving from Zone 4 (south) → appear on highway just north of south corridor
       4: { x: 40 * 48, y: 54 * 48 },
       // Arriving from Zone 2 (east) → appear in east parking lot near east exit

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -405,7 +405,11 @@ export default class Game extends Phaser.Scene {
 
       // ── Fade back in ────────────────────────────────────────────────────────
       this.cameras.main.fadeIn(250, 0, 0, 0);
-      this.cameras.main.once("camerafadeincomplete", () => {
+      // Use a timer rather than camerafadeincomplete — the camera event is
+      // unreliable when fades overlap or the scene is busy loading. If it
+      // never fires, _transitioning stays true forever and exit zones stop
+      // working. 300ms covers the 250ms fade-in plus a small safety margin.
+      this.time.delayedCall(300, () => {
         this.player.locked  = false;
         this._transitioning = false;
       });


### PR DESCRIPTION
## Root Cause

Two issues combined to block the Zone 1 → Zone 0 north return:

### 1. `camerafadeincomplete` event is unreliable
The `_transitioning` and `player.locked` flags were reset inside a `cameras.main.once('camerafadeincomplete')` callback. This event can fail to fire when fades overlap or the scene is busy loading a new tilemap — leaving `_transitioning = true` permanently. Every subsequent call to `checkExitZones()` is silently skipped by the guard at the top, so exit zones never trigger again for the rest of the session.

### 2. Entry points too close to exit triggers
Zone 1's entry point from Zone 0 was at row 5 (y=240) — only 96px from the north exit trigger's bottom edge (y=144). Any physics drift during the lock window could clip the player into the trigger before movement was allowed.

## Fix

**`game.js`** — replace `camerafadeincomplete` with `time.delayedCall(300ms)`:
```js
// Before (unreliable)
this.cameras.main.once("camerafadeincomplete", () => { ... });

// After (guaranteed)
this.time.delayedCall(300, () => {
  this.player.locked  = false;
  this._transitioning = false;
});
```

**`zone_manager.js`** — push entry points away from triggers:
- Zone 1 entry from Zone 0: row 5 → row 12 (y=240 → y=576, 432px clearance)
- Zone 0 entry from Zone 1: row 55 → row 52 (y=2640 → y=2496, 240px clearance)

## Test plan

- [ ] Zone 0 → walk south → Zone 1 loads, Juan appears on highway around row 12
- [ ] Walk north in Zone 1 → Zone 0 loads, Juan appears on south trail around row 52
- [ ] Round-trip Zone 0 → Zone 1 → Zone 0 works without page reload
- [ ] Rapid repeated transitions don't permanently lock `_transitioning`
- [ ] No regression: Zone 0 initial load, containers, workbench, rocket all work

Closes #24
🤖 Generated with [Claude Code](https://claude.com/claude-code)