### PR TITLE
fix: remove phantom Matter.js tile bodies on zone transition (#27)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -222,8 +222,9 @@ Bugs are tracked here alongside their GitHub issue. When a bug is reported:
 2. Add it to this section as ⏳
 3. Fix it, mark ✅ with commit hash, close the issue
 
-- ✅ **Juan stuck in Zone 1, north exit unresponsive** [#27](https://github.com/m3ssana/swampfire/issues/27) _(1dbe258)_
-  - Same root cause as #24; resolved by PR #26
+- ✅ **Juan stuck in Zone 1, north exit unresponsive** [#27](https://github.com/m3ssana/swampfire/issues/27)
+  - Root cause: `Tilemap.destroy()` does NOT remove Matter.js bodies from `convertTilemapLayer()` — Zone 0's static obstacle bodies persist as invisible colliders in Zone 1, blocking the north corridor
+  - Fix: added `_removeTileBodies()` to `destroyCurrentZone()` — explicitly calls `MatterTileBody.destroy()` on every tile before map teardown
 
 - ✅ **Cannot return north from Zone 1 to Zone 0 after transition** [#24](https://github.com/m3ssana/swampfire/issues/24) _(1dbe258)_
   - Root cause: `camerafadeincomplete` event unreliable after tilemap load → `_transitioning` stuck true forever

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "terser": "^5.28.1",
-        "vite": "^5.1.4"
+        "vite": "^5.1.4",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -306,6 +307,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -323,6 +341,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -338,6 +373,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -808,12 +860,121 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -828,6 +989,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -835,10 +1006,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -881,11 +1069,49 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -900,6 +1126,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
@@ -920,6 +1156,24 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/phaser": {
       "version": "3.90.0",
@@ -945,6 +1199,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1020,6 +1287,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1051,6 +1325,20 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
@@ -1068,6 +1356,50 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vite": {
@@ -1128,6 +1460,636 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
   ],
   "scripts": {
     "dev": "vite --config vite/config.dev.mjs",
-    "build": "vite build --config vite/config.prod.mjs"
+    "build": "vite build --config vite/config.prod.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-      "terser": "^5.28.1",
-      "vite": "^5.1.4"
+    "terser": "^5.28.1",
+    "vite": "^5.1.4",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "phaser": "^3.80.1",

--- a/src/gameobjects/zone_manager.js
+++ b/src/gameobjects/zone_manager.js
@@ -137,7 +137,13 @@ export default class ZoneManager {
     this.workbench?.destroy();
     this.rocket?.destroy();
 
-    // Phaser tilemap destroy removes all layers and their physics bodies
+    // Phaser's Tilemap.destroy() removes TilemapLayer game objects but does
+    // NOT call MatterTileBody.destroy() on individual tiles. The static
+    // Matter.js bodies survive in the physics world as invisible colliders,
+    // blocking the player in the next zone (root cause of bug #27).
+    // We must explicitly remove them before destroying the map.
+    this._removeTileBodies();
+
     this.map?.destroy();
 
     this.containers = [];
@@ -243,6 +249,28 @@ export default class ZoneManager {
   }
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Remove all Matter.js bodies that convertTilemapLayer() attached to tiles.
+   *
+   * Phaser's TilemapLayer.destroy() does NOT clean these up — the static bodies
+   * linger in the Matter world and collide with the player in the next zone.
+   * Each colliding tile stores its body at tile.physics.matterBody; calling
+   * .destroy() on it removes the body from the world.
+   */
+  _removeTileBodies() {
+    if (!this.map) return;
+
+    for (const layerData of this.map.layers) {
+      for (const row of layerData.data) {
+        for (const tile of row) {
+          if (tile?.physics?.matterBody) {
+            tile.physics.matterBody.destroy();
+          }
+        }
+      }
+    }
+  }
 
   /** Read a named property from a Tiled object's properties array. */
   _getProp(obj, name) {

--- a/tests/zone-tilemap-data.test.js
+++ b/tests/zone-tilemap-data.test.js
@@ -1,0 +1,168 @@
+/**
+ * Zone Tilemap Data Integrity Tests
+ *
+ * Parses the actual Tiled JSON files and verifies:
+ * - Exit objects exist with correct targetZone values
+ * - Exit corridors are free of impassable obstacle tiles
+ * - Entry points have sufficient clearance from exit triggers
+ *
+ * This catches map-editor mistakes that could silently break transitions.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const MAPS_DIR = resolve(import.meta.dirname, '../public/assets/maps');
+
+function loadZoneMap(filename) {
+  return JSON.parse(readFileSync(resolve(MAPS_DIR, filename), 'utf-8'));
+}
+
+function getObjectsByType(mapData, type) {
+  const layer = mapData.layers.find(l => l.type === 'objectgroup');
+  if (!layer) return [];
+  return layer.objects.filter(o => o.type === type);
+}
+
+function getProp(obj, name) {
+  return obj.properties?.find(p => p.name === name)?.value ?? null;
+}
+
+function getImpassableTileGIDs(mapData) {
+  const gids = new Set();
+  for (const ts of mapData.tilesets) {
+    for (const tile of (ts.tiles ?? [])) {
+      const props = Object.fromEntries((tile.properties ?? []).map(p => [p.name, p.value]));
+      if (props.impassable) {
+        gids.add(ts.firstgid + tile.id);
+      }
+    }
+  }
+  return gids;
+}
+
+function getObstacleLayer(mapData) {
+  return mapData.layers.find(l => l.name === 'obstacles' && l.type === 'tilelayer');
+}
+
+// ── Zone 1 tests (the zone where bug #27 manifests) ────────────────────────
+
+describe('Zone 1 tilemap (zone1.json)', () => {
+  let mapData;
+  let exits;
+  let impassableGIDs;
+
+  beforeAll(() => {
+    mapData = loadZoneMap('zone1.json');
+    exits = getObjectsByType(mapData, 'exit');
+    impassableGIDs = getImpassableTileGIDs(mapData);
+  });
+
+  it('has a north exit targeting Zone 0', () => {
+    const northExit = exits.find(e => getProp(e, 'targetZone') === 0);
+    expect(northExit).toBeDefined();
+    expect(northExit.y).toBe(0);           // at top of map
+    expect(northExit.width).toBeGreaterThan(0);
+    expect(northExit.height).toBeGreaterThan(0);
+  });
+
+  it('north exit targetZone is numeric (not string)', () => {
+    const northExit = exits.find(e => e.name?.includes('zone0'));
+    expect(typeof getProp(northExit, 'targetZone')).toBe('number');
+  });
+
+  it('north exit corridor is free of impassable obstacle tiles', () => {
+    const northExit = exits.find(e => getProp(e, 'targetZone') === 0);
+    const obsLayer = getObstacleLayer(mapData);
+    const tw = mapData.tilewidth;
+    const th = mapData.tileheight;
+    const mapW = mapData.width;
+
+    // Check every tile cell that falls within the exit rectangle
+    const colStart = Math.ceil(northExit.x / tw);
+    const colEnd   = Math.floor((northExit.x + northExit.width) / tw) - 1;
+    const rowStart = Math.ceil(northExit.y / th);
+    const rowEnd   = Math.floor((northExit.y + northExit.height) / th) - 1;
+
+    const blockers = [];
+    for (let row = rowStart; row <= rowEnd; row++) {
+      for (let col = colStart; col <= colEnd; col++) {
+        const tileGID = obsLayer.data[row * mapW + col];
+        if (impassableGIDs.has(tileGID)) {
+          blockers.push({ row, col, x: col * tw, y: row * th, tileGID });
+        }
+      }
+    }
+
+    expect(blockers).toEqual([]);
+  });
+
+  it('entry point from Zone 0 is NOT inside any exit rectangle', () => {
+    const entryX = 40 * 48;   // 1920 — from ZONES config
+    const entryY = 12 * 48;   // 576
+
+    for (const exit of exits) {
+      const inside = entryX >= exit.x && entryX <= exit.x + exit.width &&
+                     entryY >= exit.y && entryY <= exit.y + exit.height;
+      expect(inside, `entry (${entryX},${entryY}) is inside exit "${exit.name}"`).toBe(false);
+    }
+  });
+});
+
+// ── Zone 0 tests ────────────────────────────────────────────────────────────
+
+describe('Zone 0 tilemap (zone0.json)', () => {
+  let mapData;
+  let exits;
+  let impassableGIDs;
+
+  beforeAll(() => {
+    mapData = loadZoneMap('zone0.json');
+    exits = getObjectsByType(mapData, 'exit');
+    impassableGIDs = getImpassableTileGIDs(mapData);
+  });
+
+  it('has a south exit targeting Zone 1', () => {
+    const southExit = exits.find(e => getProp(e, 'targetZone') === 1);
+    expect(southExit).toBeDefined();
+    expect(southExit.width).toBeGreaterThan(0);
+    expect(southExit.height).toBeGreaterThan(0);
+  });
+
+  it('south exit corridor is free of impassable obstacle tiles', () => {
+    const southExit = exits.find(e => getProp(e, 'targetZone') === 1);
+    const obsLayer = getObstacleLayer(mapData);
+    const tw = mapData.tilewidth;
+    const th = mapData.tileheight;
+    const mapW = mapData.width;
+
+    const colStart = Math.ceil(southExit.x / tw);
+    const colEnd   = Math.floor((southExit.x + southExit.width) / tw) - 1;
+    const rowStart = Math.ceil(southExit.y / th);
+    const rowEnd   = Math.floor((southExit.y + southExit.height) / th) - 1;
+
+    const blockers = [];
+    for (let row = rowStart; row <= rowEnd; row++) {
+      for (let col = colStart; col <= colEnd; col++) {
+        const tileGID = obsLayer.data[row * mapW + col];
+        if (impassableGIDs.has(tileGID)) {
+          blockers.push({ row, col, x: col * tw, y: row * th, tileGID });
+        }
+      }
+    }
+
+    expect(blockers).toEqual([]);
+  });
+
+  it('entry point from Zone 1 is NOT inside any exit rectangle', () => {
+    const entryX = 40 * 48;   // 1920
+    const entryY = 52 * 48;   // 2496
+
+    for (const exit of exits) {
+      const inside = entryX >= exit.x && entryX <= exit.x + exit.width &&
+                     entryY >= exit.y && entryY <= exit.y + exit.height;
+      expect(inside, `entry (${entryX},${entryY}) is inside exit "${exit.name}"`).toBe(false);
+    }
+  });
+});

--- a/tests/zone-transition.test.js
+++ b/tests/zone-transition.test.js
@@ -1,0 +1,239 @@
+/**
+ * Zone Transition Tests
+ *
+ * Validates the exit-detection logic and transition lock behaviour that caused
+ * bugs #24 and #27 (Juan stuck in Zone 1, north exit unresponsive).
+ *
+ * These tests exercise the pure logic extracted from game.js — no Phaser runtime
+ * needed. We mock just enough of the scene/player/zone to drive checkExitZones()
+ * and transitionToZone().
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Extracted constants from zone maps ──────────────────────────────────────
+
+const ZONE0_SOUTH_EXIT = { x: 1632, y: 2736, width: 624, height: 144, targetZone: 1 };
+const ZONE1_NORTH_EXIT = { x: 1632, y: 0,    width: 624, height: 144, targetZone: 0 };
+const ZONE1_SOUTH_EXIT = { x: 1632, y: 2736, width: 624, height: 144, targetZone: 4 };
+const ZONE1_EAST_EXIT  = { x: 3696, y: 1200, width: 144, height: 528, targetZone: 2 };
+
+// Entry point when arriving in Zone 1 from Zone 0 (row 12)
+const ZONE1_ENTRY_FROM_Z0 = { x: 40 * 48, y: 12 * 48 };   // (1920, 576)
+// Entry point when arriving in Zone 0 from Zone 1 (row 52)
+const ZONE0_ENTRY_FROM_Z1 = { x: 40 * 48, y: 52 * 48 };   // (1920, 2496)
+
+// ── AABB overlap (mirrors checkExitZones logic in game.js) ──────────────────
+
+function isInsideExit(px, py, exit) {
+  return px >= exit.x && px <= exit.x + exit.width &&
+         py >= exit.y && py <= exit.y + exit.height;
+}
+
+// ── Mock scene ──────────────────────────────────────────────────────────────
+
+function createMockScene() {
+  const transitionLog = [];
+
+  const scene = {
+    _transitioning: false,
+    player: { sprite: { x: 0, y: 0 }, locked: false },
+    zone: { exits: [] },
+    nearbyInteractable: null,
+
+    /** Mirrors checkExitZones() from game.js lines 343-357 */
+    checkExitZones() {
+      if (this._transitioning || !this.player?.sprite) return null;
+
+      const px = this.player.sprite.x;
+      const py = this.player.sprite.y;
+
+      for (const exit of (this.zone.exits ?? [])) {
+        if (isInsideExit(px, py, exit)) {
+          this.transitionToZone(exit.targetZone);
+          return exit.targetZone;
+        }
+      }
+      return null;
+    },
+
+    /** Simplified transitionToZone — records the call and sets lock */
+    transitionToZone(targetZoneId) {
+      if (this._transitioning) return;
+      this._transitioning = true;
+      this.player.locked = true;
+      this.nearbyInteractable = null;
+      transitionLog.push(targetZoneId);
+    },
+
+    /** Simulate the 300ms timer completing (unlock) */
+    completeTransition() {
+      this.player.locked = false;
+      this._transitioning = false;
+    },
+
+    getTransitionLog() { return transitionLog; },
+  };
+
+  return scene;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Exit zone AABB detection', () => {
+  it('detects player inside Zone 1 north exit', () => {
+    expect(isInsideExit(1920, 72, ZONE1_NORTH_EXIT)).toBe(true);
+  });
+
+  it('detects player at exact exit boundaries', () => {
+    // Top-left corner
+    expect(isInsideExit(1632, 0, ZONE1_NORTH_EXIT)).toBe(true);
+    // Bottom-right corner
+    expect(isInsideExit(2256, 144, ZONE1_NORTH_EXIT)).toBe(true);
+  });
+
+  it('rejects player outside exit rectangle', () => {
+    // Just above (negative y)
+    expect(isInsideExit(1920, -1, ZONE1_NORTH_EXIT)).toBe(false);
+    // Just below
+    expect(isInsideExit(1920, 145, ZONE1_NORTH_EXIT)).toBe(false);
+    // Just left
+    expect(isInsideExit(1631, 72, ZONE1_NORTH_EXIT)).toBe(false);
+    // Just right
+    expect(isInsideExit(2257, 72, ZONE1_NORTH_EXIT)).toBe(false);
+  });
+
+  it('rejects player at Zone 1 entry point (should NOT re-trigger exit)', () => {
+    // Entry point from Zone 0: (1920, 576) — must be outside north exit (y=0..144)
+    expect(isInsideExit(ZONE1_ENTRY_FROM_Z0.x, ZONE1_ENTRY_FROM_Z0.y, ZONE1_NORTH_EXIT))
+      .toBe(false);
+  });
+
+  it('rejects player at Zone 0 entry point (should NOT re-trigger south exit)', () => {
+    // Entry point from Zone 1: (1920, 2496) — must be outside south exit (y=2736..2880)
+    expect(isInsideExit(ZONE0_ENTRY_FROM_Z1.x, ZONE0_ENTRY_FROM_Z1.y, ZONE0_SOUTH_EXIT))
+      .toBe(false);
+  });
+});
+
+describe('Entry point clearance from exit triggers', () => {
+  it('Zone 1 entry from Z0 has >= 240px clearance from north exit', () => {
+    const exitBottom = ZONE1_NORTH_EXIT.y + ZONE1_NORTH_EXIT.height; // 144
+    const entryY = ZONE1_ENTRY_FROM_Z0.y;                            // 576
+    expect(entryY - exitBottom).toBeGreaterThanOrEqual(240);
+  });
+
+  it('Zone 0 entry from Z1 has >= 240px clearance from south exit', () => {
+    const exitTop = ZONE0_SOUTH_EXIT.y;                               // 2736
+    const entryY = ZONE0_ENTRY_FROM_Z1.y;                             // 2496
+    expect(exitTop - entryY).toBeGreaterThanOrEqual(240);
+  });
+});
+
+describe('checkExitZones — transition lock', () => {
+  let scene;
+
+  beforeEach(() => {
+    scene = createMockScene();
+    scene.zone.exits = [ZONE1_NORTH_EXIT, ZONE1_SOUTH_EXIT, ZONE1_EAST_EXIT];
+  });
+
+  it('triggers transition when player walks into north exit', () => {
+    scene.player.sprite.x = 1920;
+    scene.player.sprite.y = 72;
+
+    const result = scene.checkExitZones();
+    expect(result).toBe(0); // target: Zone 0
+    expect(scene._transitioning).toBe(true);
+    expect(scene.player.locked).toBe(true);
+  });
+
+  it('does NOT trigger when _transitioning is true', () => {
+    scene._transitioning = true;
+    scene.player.sprite.x = 1920;
+    scene.player.sprite.y = 72;
+
+    const result = scene.checkExitZones();
+    expect(result).toBeNull();
+    expect(scene.getTransitionLog()).toHaveLength(0);
+  });
+
+  it('does NOT trigger when player sprite is null', () => {
+    scene.player.sprite = null;
+    const result = scene.checkExitZones();
+    expect(result).toBeNull();
+  });
+
+  it('does NOT double-trigger on consecutive frames', () => {
+    scene.player.sprite.x = 1920;
+    scene.player.sprite.y = 72;
+
+    scene.checkExitZones(); // first frame — triggers
+    scene.checkExitZones(); // second frame — _transitioning blocks it
+
+    expect(scene.getTransitionLog()).toEqual([0]); // only one transition
+  });
+});
+
+describe('Full round-trip: Zone 0 → Zone 1 → Zone 0', () => {
+  it('completes a full round-trip without getting stuck', () => {
+    const scene = createMockScene();
+
+    // ── Start in Zone 0, walk south ──
+    scene.zone.exits = [ZONE0_SOUTH_EXIT];
+    scene.player.sprite.x = 1920;
+    scene.player.sprite.y = 2800; // inside south exit
+
+    scene.checkExitZones();
+    expect(scene.getTransitionLog()).toEqual([1]);
+    expect(scene._transitioning).toBe(true);
+
+    // ── Simulate transition completion (300ms timer fires) ──
+    // Zone 1 exits are loaded, player repositioned at entry point
+    scene.zone.exits = [ZONE1_NORTH_EXIT, ZONE1_SOUTH_EXIT, ZONE1_EAST_EXIT];
+    scene.player.sprite.x = ZONE1_ENTRY_FROM_Z0.x;
+    scene.player.sprite.y = ZONE1_ENTRY_FROM_Z0.y;
+    scene.completeTransition();
+
+    // Verify: player at entry point does NOT immediately re-trigger an exit
+    expect(scene._transitioning).toBe(false);
+    const accidentalTrigger = scene.checkExitZones();
+    expect(accidentalTrigger).toBeNull();
+
+    // ── Walk north to Zone 1 exit ──
+    scene.player.sprite.y = 72; // inside north exit corridor
+
+    const returnTrip = scene.checkExitZones();
+    expect(returnTrip).toBe(0); // triggers return to Zone 0
+    expect(scene._transitioning).toBe(true);
+    expect(scene.getTransitionLog()).toEqual([1, 0]);
+
+    // ── Complete return transition ──
+    scene.zone.exits = [ZONE0_SOUTH_EXIT];
+    scene.player.sprite.x = ZONE0_ENTRY_FROM_Z1.x;
+    scene.player.sprite.y = ZONE0_ENTRY_FROM_Z1.y;
+    scene.completeTransition();
+
+    // Verify: back in Zone 0, not stuck
+    expect(scene._transitioning).toBe(false);
+    expect(scene.player.locked).toBe(false);
+    expect(scene.checkExitZones()).toBeNull(); // not near any exit
+  });
+});
+
+describe('Tilemap exit data integrity', () => {
+  it('Zone 1 north exit targets Zone 0', () => {
+    expect(ZONE1_NORTH_EXIT.targetZone).toBe(0);
+  });
+
+  it('Zone 0 south exit targets Zone 1', () => {
+    expect(ZONE0_SOUTH_EXIT.targetZone).toBe(1);
+  });
+
+  it('exit rectangles have non-zero dimensions', () => {
+    for (const exit of [ZONE0_SOUTH_EXIT, ZONE1_NORTH_EXIT, ZONE1_SOUTH_EXIT, ZONE1_EAST_EXIT]) {
+      expect(exit.width).toBeGreaterThan(0);
+      expect(exit.height).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause:** `Tilemap.destroy()` does NOT remove Matter.js bodies created by `convertTilemapLayer()` — Zone 0's static obstacle bodies persist as invisible colliders in Zone 1, blocking the north exit corridor and trapping Juan
- **Fix:** Added `_removeTileBodies()` to `destroyCurrentZone()` that explicitly calls `MatterTileBody.destroy()` on every tile before map teardown
- Added vitest with 22 tests covering zone transition logic and tilemap data integrity

## Details

When `convertTilemapLayer()` creates static Matter.js bodies for impassable tiles, those bodies are stored on individual `tile.physics.matterBody` objects. Phaser's `TilemapLayer.destroy()` calls `GameObject.prototype.destroy()` but never iterates the tiles to clean up their physics bodies. The bodies remain in the Matter world as invisible static colliders.

Zone 0 has a solid wall of impassable tiles at rows 0-2, cols 35-44 (the map border). In Zone 1, that exact coordinate range is the road corridor leading to the north exit. Juan walks north and hits an invisible wall at y≈144.

![juan-stuck-zone1](screenshots/juan-stuck-zone1.png)

## Test plan
- [ ] Start in Zone 0, walk south to Zone 1 — transition works
- [ ] In Zone 1, walk north along the road to the top of the map — transition back to Zone 0 fires (was blocked before)
- [ ] Repeat round-trip 3+ times — no stuck states, no phantom collisions
- [ ] `npm test` passes (22 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)