### PR TITLE
feat: StormManager — Phase 4.1 storm phase system

### DIFF
--- a/src/gameobjects/storm_manager.js
+++ b/src/gameobjects/storm_manager.js
@@ -1,0 +1,196 @@
+/**
+ * StormManager
+ *
+ * Manages all four storm phases driven by the registry timeLeft countdown.
+ * Owns rain particles, darkness overlay, and camera shake for Phase 4.
+ * Communicates phase changes back to HUDScene via registry.stormPhase.
+ *
+ * Phase thresholds (timeLeft in seconds):
+ *   Phase 1  3600 – 2700  Warning      light rain
+ *   Phase 2  2699 – 1800  Evacuation   moderate rain
+ *   Phase 3  1799 – 900   Storm Surge  heavy rain, darkness
+ *   Phase 4   899 – 0     Landfall     intense + lightning
+ */
+
+// ── Pure phase logic (re-exported for unit tests) ──────────────────────────
+export { getPhaseForTimeLeft } from './storm_phase_logic.js';
+
+// ── Per-phase rain config ──────────────────────────────────────────────────
+const RAIN_CONFIG = {
+  1: { quantity: 1,  freq: 120, speedY: { min: 280, max: 360 }, alpha: { start: 0.25, end: 0 }, lifespan: 900 },
+  2: { quantity: 2,  freq:  80, speedY: { min: 320, max: 440 }, alpha: { start: 0.40, end: 0 }, lifespan: 900 },
+  3: { quantity: 4,  freq:  40, speedY: { min: 380, max: 520 }, alpha: { start: 0.55, end: 0 }, lifespan: 900 },
+  4: { quantity: 8,  freq:  20, speedY: { min: 460, max: 640 }, alpha: { start: 0.70, end: 0 }, lifespan: 900 },
+};
+
+// ── Phase transition toasts ────────────────────────────────────────────────
+const TOAST = {
+  2: 'PHASE 2 — EVACUATE NOW',
+  3: 'PHASE 3 — STORM SURGE',
+  4: 'PHASE 4 — LANDFALL',
+};
+
+// ── Darkness overlay alpha per phase ──────────────────────────────────────
+const DARK_ALPHA = { 1: 0, 2: 0.10, 3: 0.28, 4: 0.50 };
+
+// ── Flash colours per phase transition ────────────────────────────────────
+const FLASH = {
+  2: [0, 0x44, 0xff],
+  3: [0, 0,    0x88],
+  4: [0xff, 0xff, 0xff],
+};
+
+// ── Shake per phase transition ────────────────────────────────────────────
+const TRANSITION_SHAKE = { 2: null, 3: [600, 0.006], 4: [800, 0.010] };
+
+import { getPhaseForTimeLeft } from './storm_phase_logic.js';
+
+export default class StormManager {
+  /**
+   * @param {Phaser.Scene} scene  — the active GameScene
+   */
+  constructor(scene) {
+    this._scene        = scene;
+    this._currentPhase = 1;
+    this._destroyed    = false;
+    this._shakeTimer   = null;
+    this._lightningTimer = null;
+
+    this._buildOverlay();
+    this._buildRainEmitter(1);
+    this._listenForTimeLeft();
+
+    this._scene.events.once('shutdown', this.destroy, this);
+  }
+
+  // ── Internal builders ────────────────────────────────────────────────────
+
+  _buildOverlay() {
+    const { width, height } = this._scene.sys.game.config;
+    this._overlay = this._scene.add
+      .rectangle(width / 2, height / 2, width, height, 0x000022, 0)
+      .setScrollFactor(0)
+      .setDepth(85);
+  }
+
+  _buildRainEmitter(phase) {
+    if (this._emitter) {
+      this._emitter.destroy();
+      this._emitter = null;
+    }
+    const cfg   = RAIN_CONFIG[phase];
+    const width = this._scene.sys.game.config.width;
+
+    this._emitter = this._scene.add.particles(0, -10, 'rain-drop', {
+      x:        { min: 0, max: width },
+      speedX:   0,
+      speedY:   cfg.speedY,
+      quantity:  cfg.quantity,
+      lifespan:  cfg.lifespan,
+      alpha:     cfg.alpha,
+      frequency: cfg.freq,
+      tint:      0xaaddff,
+    });
+
+    this._emitter.setScrollFactor(0);
+    this._emitter.setDepth(86);
+  }
+
+  // ── Registry listener ────────────────────────────────────────────────────
+
+  _listenForTimeLeft() {
+    this._onTimeLeft = (value) => this._onTick(value);
+    this._scene.registry.events.on('changedata-timeLeft', this._onTimeLeft, this);
+  }
+
+  _onTick(seconds) {
+    const newPhase = getPhaseForTimeLeft(seconds);
+    if (newPhase === this._currentPhase) return;
+    this._currentPhase = newPhase;
+    this._applyPhase(newPhase);
+  }
+
+  // ── Phase transition ─────────────────────────────────────────────────────
+
+  _applyPhase(phase) {
+    // Rain
+    this._buildRainEmitter(phase);
+
+    // Darkness tween
+    this._scene.tweens.add({
+      targets:  this._overlay,
+      alpha:    DARK_ALPHA[phase],
+      duration: 4000,
+      ease:     'Linear',
+    });
+
+    // Flash
+    const fc = FLASH[phase];
+    if (fc) this._scene.cameras.main.flash(300, fc[0], fc[1], fc[2]);
+
+    // Shake
+    const sh = TRANSITION_SHAKE[phase];
+    if (sh) this._scene.cameras.main.shake(sh[0], sh[1]);
+
+    // Continuous shake for Phase 4
+    if (phase === 4) {
+      this._shakeTimer = this._scene.time.addEvent({
+        delay:    4000,
+        loop:     true,
+        callback: () => {
+          if (!this._destroyed) this._scene.cameras.main.shake(600, 0.007);
+        },
+      });
+      this._startLightning();
+    }
+
+    // Toast
+    if (TOAST[phase]) {
+      this._scene.registry.set('hudToast', TOAST[phase] + '|' + Date.now());
+    }
+
+    // Notify HUD
+    this._scene.registry.set('stormPhase', phase);
+  }
+
+  // ── Phase 4 lightning ────────────────────────────────────────────────────
+
+  _startLightning() {
+    const scheduleNext = () => {
+      if (this._destroyed) return;
+      const delay = Phaser.Math.Between(8000, 20000);
+      this._lightningTimer = this._scene.time.delayedCall(delay, () => {
+        if (this._destroyed) return;
+        this._scene.cameras.main.flash(80, 255, 255, 255);
+        this._scene.time.delayedCall(140, () => {
+          if (!this._destroyed) this._scene.cameras.main.flash(60, 255, 255, 255);
+        });
+        scheduleNext();
+      });
+    };
+    scheduleNext();
+  }
+
+  // ── Cleanup ──────────────────────────────────────────────────────────────
+
+  destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
+
+    this._scene?.registry.events.off('changedata-timeLeft', this._onTimeLeft, this);
+
+    this._emitter?.destroy();
+    this._emitter = null;
+
+    this._overlay?.destroy();
+    this._overlay = null;
+
+    this._shakeTimer?.remove(false);
+    this._shakeTimer = null;
+
+    this._lightningTimer?.remove(false);
+    this._lightningTimer = null;
+
+    this._scene = null;
+  }
+}

--- a/src/gameobjects/storm_phase_logic.js
+++ b/src/gameobjects/storm_phase_logic.js
@@ -1,0 +1,17 @@
+/**
+ * Pure phase logic — no Phaser dependency.
+ * Exported separately so unit tests can import it without pulling in
+ * the Phaser-dependent StormManager class.
+ *
+ * Phase thresholds (timeLeft in seconds):
+ *   Phase 1  3600 – 2700  Warning
+ *   Phase 2  2699 – 1800  Evacuation
+ *   Phase 3  1799 – 900   Storm Surge
+ *   Phase 4   899 – 0     Landfall
+ */
+export function getPhaseForTimeLeft(seconds) {
+  if (seconds >= 2700) return 1;
+  if (seconds >= 1800) return 2;
+  if (seconds >= 900)  return 3;
+  return 4;
+}

--- a/src/scenes/bootloader.js
+++ b/src/scenes/bootloader.js
@@ -10,6 +10,7 @@ export default class Bootloader extends Phaser.Scene {
     this.generateItemTexture();
     this.generateWorkbenchTexture();
     this.generateRocketTexture();
+    this.generateRainDropTexture();
     this.createBars();
     this.setLoadEvents();
     this.loadFonts();
@@ -62,6 +63,19 @@ export default class Bootloader extends Phaser.Scene {
     g.fillTriangle(32, 56, 24, 36, 24, 62); // right fin
     g.fillRect(10, 62, 12, 8);              // nozzle
     g.generateTexture('rocket_pixel', 32, 72);
+    g.destroy();
+  }
+
+  /*
+    Programmatically generates a 2×8 white rain drop texture.
+    Drawn before asset loads so 'rain-drop' is available immediately when
+    StormManager creates the particle emitter.
+  */
+  generateRainDropTexture() {
+    const g = this.make.graphics({ add: false });
+    g.fillStyle(0xffffff, 1);
+    g.fillRect(0, 0, 2, 8);
+    g.generateTexture('rain-drop', 2, 8);
     g.destroy();
   }
 

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -1,5 +1,6 @@
 import Player                         from "../gameobjects/player";
 import ZoneManager, { isZoneDefined } from "../gameobjects/zone_manager";
+import StormManager                   from "../gameobjects/storm_manager";
 
 export default class Game extends Phaser.Scene {
   constructor() {
@@ -33,6 +34,7 @@ export default class Game extends Phaser.Scene {
     this.launchHUD();
     this.loadAudios();
     this.listenForGameOver();
+    this.stormManager = new StormManager(this);
   }
 
   // ─── Map ───────────────────────────────────────────────────────────────────
@@ -283,6 +285,15 @@ export default class Game extends Phaser.Scene {
       y: { from: text.y - 10, to: text.y - 60 },
       onComplete: () => text.destroy(),
     });
+  }
+
+  /*
+    Sends a toast message to HUDScene via the shared registry.
+    HUDScene listens for changedata-hudToast and renders a centered fade-out label.
+    The pipe+timestamp suffix forces re-fire even if the same message repeats.
+  */
+  showToast(message) {
+    this.registry.set('hudToast', `${message}|${Date.now()}`);
   }
 
   // ─── Camera ────────────────────────────────────────────────────────────────

--- a/src/scenes/hud.js
+++ b/src/scenes/hud.js
@@ -41,6 +41,7 @@ export default class HUD extends Phaser.Scene {
     this.updateHearts(this.registry.get("hp") ?? MAX_HP);
     this.updateXP(this.registry.get("xp") ?? 0);
     this.updateSystems(this.registry.get("systemsInstalled") ?? 0);
+    this.updatePhase(this.registry.get('stormPhase') ?? 1);
 
     // Tick every real second — HUDScene owns the countdown
     this.countdown = this.time.addEvent({
@@ -154,6 +155,8 @@ export default class HUD extends Phaser.Scene {
       case "hp":              this.updateHearts(value);       break;
       case "xp":              this.updateXP(value);           break;
       case "systemsInstalled": this.updateSystems(value);     break;
+      case "stormPhase":      this.updatePhase(value);        break;
+      case "hudToast":        this.showStormToast(value);     break;
     }
   }
 
@@ -164,7 +167,7 @@ export default class HUD extends Phaser.Scene {
     const s = (seconds % 60).toString().padStart(2, "0");
     this.timerText.setText(`${m}:${s}`);
 
-    // Colour shifts signal urgency
+    // Final-minute urgency pulse — phase tint governs everything above 60s
     if (seconds <= 60) {
       this.timerText.setTint(0xff3333);
       if (!this.timerPulse) {
@@ -176,11 +179,49 @@ export default class HUD extends Phaser.Scene {
           repeat: -1,
         });
       }
-    } else if (seconds <= 300) {
-      this.timerText.setTint(0xff8800);
-    } else {
-      this.timerText.setTint(0x4fffaa);
     }
+  }
+
+  updatePhase(phase) {
+    const PHASE_TINTS = { 1: 0x4fffaa, 2: 0xffee44, 3: 0xff8800, 4: 0xff2222 };
+    const tint = PHASE_TINTS[phase] ?? 0x4fffaa;
+
+    // Don't override the final-minute urgency pulse
+    const timeLeft = this.registry.get('timeLeft') ?? 3600;
+    if (timeLeft > 60) {
+      this.timerText.setTint(tint);
+    }
+  }
+
+  showStormToast(raw) {
+    if (!raw) return;
+    // Strip timestamp suffix added to force re-fire on repeated messages
+    const message = raw.split('|')[0].trim();
+    if (!message) return;
+
+    this._toastText?.destroy();
+    this._toastText = null;
+
+    // Position below the top HUD bar (around y=120 on a 640px screen)
+    this._toastText = this.add
+      .bitmapText(this.cameras.main.width / 2, 120, 'default', message, 20)
+      .setOrigin(0.5)
+      .setTint(0xff8800)
+      .setScrollFactor(0)
+      .setDepth(20)
+      .setAlpha(0);
+
+    this.tweens.add({
+      targets:  this._toastText,
+      alpha:    { from: 0, to: 1 },
+      duration: 400,
+      hold:     2500,
+      yoyo:     true,
+      onComplete: () => {
+        this._toastText?.destroy();
+        this._toastText = null;
+      },
+    });
   }
 
   updateHearts(hp) {
@@ -202,5 +243,7 @@ export default class HUD extends Phaser.Scene {
 
   shutdown() {
     this.registry.events.off("changedata", this.onRegistryChange, this);
+    this._toastText?.destroy();
+    this._toastText = null;
   }
 }

--- a/src/scenes/transition.js
+++ b/src/scenes/transition.js
@@ -289,6 +289,8 @@ export default class Transition extends Phaser.Scene {
     this.registry.set("timerExpired", false);
     this.registry.set("inventory", []);  // cleared fresh each run; fed by item pickups
     this.registry.set("systemsInstalled", 0); // reset rocket progress each run
+    this.registry.set("stormPhase", 1);
+    this.registry.set("hudToast", "");
 
     this.cameras.main.fade(300, 0, 0, 0);
     this.cameras.main.once("camerafadeoutcomplete", () => {

--- a/tests/game-logic.test.js
+++ b/tests/game-logic.test.js
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { getPhaseForTimeLeft } from '../src/gameobjects/storm_phase_logic.js';
 
 // ── Crafting system ─────────────────────────────────────────────────────────
 
@@ -404,5 +405,46 @@ describe('Core Gameplay Loop', () => {
     expect(systemsInstalled).toBe(4);
     expect(xp).toBe(60);
     expect(timeLeft).toBe(3600);
+  });
+});
+
+// ── Storm phase logic ────────────────────────────────────────────────────────
+
+describe('getPhaseForTimeLeft', () => {
+  it('returns 1 at full time (3600s)', () => {
+    expect(getPhaseForTimeLeft(3600)).toBe(1);
+  });
+  it('returns 1 at the Phase 1 lower boundary (2700s)', () => {
+    expect(getPhaseForTimeLeft(2700)).toBe(1);
+  });
+  it('returns 2 one second below Phase 1 boundary (2699s)', () => {
+    expect(getPhaseForTimeLeft(2699)).toBe(2);
+  });
+  it('returns 2 at the Phase 2 lower boundary (1800s)', () => {
+    expect(getPhaseForTimeLeft(1800)).toBe(2);
+  });
+  it('returns 3 one second below Phase 2 boundary (1799s)', () => {
+    expect(getPhaseForTimeLeft(1799)).toBe(3);
+  });
+  it('returns 3 at the Phase 3 lower boundary (900s)', () => {
+    expect(getPhaseForTimeLeft(900)).toBe(3);
+  });
+  it('returns 4 one second below Phase 3 boundary (899s)', () => {
+    expect(getPhaseForTimeLeft(899)).toBe(4);
+  });
+  it('returns 4 at zero (timer expired)', () => {
+    expect(getPhaseForTimeLeft(0)).toBe(4);
+  });
+  it('detects a transition: Phase 1 → Phase 2', () => {
+    expect(getPhaseForTimeLeft(2701)).toBe(1);
+    expect(getPhaseForTimeLeft(2699)).toBe(2);
+  });
+  it('detects a transition: Phase 2 → Phase 3', () => {
+    expect(getPhaseForTimeLeft(1801)).toBe(2);
+    expect(getPhaseForTimeLeft(1799)).toBe(3);
+  });
+  it('detects a transition: Phase 3 → Phase 4', () => {
+    expect(getPhaseForTimeLeft(901)).toBe(3);
+    expect(getPhaseForTimeLeft(899)).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary

- **4 escalating storm phases** driven by the existing `registry.timeLeft` countdown — no new timer needed
- **Rain particle system**: screen-space `setScrollFactor(0)` emitter with dedicated `rain-drop` texture; intensity scales 1→2→4→8 particles/emit per phase
- **Darkness overlay**: full-screen rectangle at depth 85, tweens alpha `0 → 0.10 → 0.28 → 0.50` over 4 seconds per transition
- **Phase transitions**: flash (blue→dark blue→white), camera shake, HUD timer tint shift (green→yellow→orange→red)
- **Phase 4 Landfall**: looping camera shake every 4s, random lightning double-flash every 8–20s
- **Toast notifications**: cross-scene via `registry.hudToast` key — HUD renders centered fade-out BitmapText with 2.5s hold
- **Clean separation**: `storm_phase_logic.js` is pure JS (no Phaser), importable in vitest; `StormManager` class keeps all Phaser-dependent code

## Test plan

- [x] 127 unit tests passing (11 new: all phase boundary conditions for `getPhaseForTimeLeft`)
- [x] Build clean
- [x] Phase 1→2 boundary: `getPhaseForTimeLeft(2700)=1`, `getPhaseForTimeLeft(2699)=2`
- [x] Phase 2→3 boundary: `getPhaseForTimeLeft(1800)=2`, `getPhaseForTimeLeft(1799)=3`
- [x] Phase 3→4 boundary: `getPhaseForTimeLeft(900)=3`, `getPhaseForTimeLeft(899)=4`
- [x] `StormManager.destroy()` is idempotent (double-call guard), cleans up emitter + overlay + shake timer + lightning timer + registry listener
- [x] `hudToast` pipe+timestamp suffix ensures repeated phase messages always re-fire
- [ ] Manual: visually verify rain appears at game start and intensifies at each phase threshold
- [ ] Manual: verify HUD timer tints shift per phase
- [ ] Manual: verify Phase 4 lightning flashes and looping shake

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)