### PR TITLE
chore: mark 4.1 complete in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -144,11 +144,14 @@ Each task is small enough to fit in a single Claude Code session.
 
 ## Phase 4 -- Storm + Hazard Systems
 
-- ⏳ **4.1 Storm phase system** [#6](https://github.com/m3ssana/swampfire/issues/6)
-  - `StormManager` tracks 4 phases based on countdown timer
-  - Phase 1 (60-45 min): light rain particle overlay
-  - Phase transitions: screen shake, thunder, HUD toast
-  - Weather visuals intensify each phase (rain density, wind, darkness)
+- ✅ **4.1 Storm phase system** [#6](https://github.com/m3ssana/swampfire/issues/6) _(b74aa10)_
+  - `StormManager` + `storm_phase_logic.js` (pure, unit-tested phase fn)
+  - Phase 1 (60-45 min): light rain particle overlay, green HUD
+  - Phase 2 (45-30 min): moderate rain, blue flash, yellow HUD, toast
+  - Phase 3 (30-15 min): heavy rain, shake, 28% darkness overlay, orange HUD, toast
+  - Phase 4 (15-0 min): intense rain, looping shake, lightning (8-20s), 50% darkness, red HUD, toast
+  - Cross-scene toasts via `registry.hudToast`; HUD timer tint driven by `registry.stormPhase`
+  - 11 new unit tests (127 total)
 
 - ⏳ **4.2 Hazard game objects** [#7](https://github.com/m3ssana/swampfire/issues/7)
   - Rattlesnakes (Zone 0 edges, Zone 3)


### PR DESCRIPTION
Marks task 4.1 (StormManager) as ✅ in TODO.md following the merge of PR #38 (b74aa10).

Per updated workflow: TODO.md should ship inside the feature PR going forward. This chore PR covers the gap for 4.1 since the rule was established after that PR was already open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)