### PR TITLE
feat(launch): rocket launch cinematic sequence (#13)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -200,7 +200,7 @@ Each task is small enough to fit in a single Claude Code session.
 
 ## Phase 6 -- Endgame + Meta
 
-- ⏳ **6.1 Launch sequence** [#13](https://github.com/m3ssana/swampfire/issues/13)
+- ✅ **6.1 Launch sequence** [#13](https://github.com/m3ssana/swampfire/issues/13) _(cinematic: ignition flash → engine particles → camera pan/zoom → rocket ascent → under-the-wire toast → fade to outro)_
   - When all 4 systems installed and player interacts with rocket
   - Cinematic: camera pulls back, rocket ignites, lifts off
   - Screen fades to EndRunScreen with WIN state

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -36,6 +36,12 @@ export default class Game extends Phaser.Scene {
     // Lock flag — true while a zone-transition fade is in progress
     this._transitioning = false;
 
+    // Lock flag — true while the rocket launch cinematic is playing
+    this._launching = false;
+
+    // Particle emitter created during the launch cinematic; cleaned up on fade-complete
+    this._launchEmitter = null;
+
     // Pending XP popup map — keyed by context ('loot'|'craft'|'install')
     // Used by showXPGain() to merge rapid same-context grants into one popup
     this._xpPending = {};
@@ -182,6 +188,7 @@ export default class Game extends Phaser.Scene {
   */
   listenForGameOver() {
     const onExpired = (parent, value) => {
+      if (this._launching) return;
       if (value === true) this.endRun("timeout");
     };
     this.registry.events.on("changedata-timerExpired", onExpired, this);
@@ -193,9 +200,9 @@ export default class Game extends Phaser.Scene {
   /*
     Stop the HUD and transition to the end-run screen with the given state.
   */
-  endRun(state) {
+  endRun(state, options = {}) {
     this.scene.stop("hud");
-    this.scene.start("outro", { state });
+    this.scene.start("outro", { state, underTheWire: options.underTheWire ?? false });
   }
 
   // ─── HUD ───────────────────────────────────────────────────────────────────
@@ -521,10 +528,104 @@ export default class Game extends Phaser.Scene {
   }
 
   /*
-    Player completed the run. Stop the HUD then hand off to the end screen.
-    Wired to actual win condition in task 1.4.
+    Player completed the run. Plays a ~4-second rocket launch cinematic before
+    handing off to the end screen via endRun('victory').
+
+    Sequence:
+      t=0      — guard flags, ignition flash + camera shake
+      t=100ms  — engine exhaust particle emitter starts
+      t=350ms  — camera detaches from player, pans to rocket
+      t=700ms  — camera zooms out, rocket ascent tween begins
+      t=1000ms — under-the-wire toast (only if timeLeft < 2 min)
+      t=2600ms — final rumble shake
+      t=3200ms — fade to black → endRun('victory')
   */
   finishScene() {
-    this.endRun("victory");
+    // ── Step 1 — Initiate ────────────────────────────────────────────────────
+    this._launching = true;
+    this.player.locked = true;
+    this.nearbyInteractable = null;
+    this.hideInteractPrompt();
+
+    const timeLeft = this.registry.get('timeLeft') ?? 0;
+    const underTheWire = timeLeft < 120; // < 2 min remaining
+
+    const rocket = this.zone?.rocket?.sprite;
+
+    // ── Step 2 — Ignition flash ──────────────────────────────────────────────
+    this.cameras.main.flash(350, 255, 140, 0); // orange ignition flash
+    this.cameras.main.shake(300, 0.014);
+
+    // ── Step 3 — Engine particles (t=100ms) ─────────────────────────────────
+    this.time.delayedCall(100, () => {
+      if (!this.scene?.isActive()) return;
+      if (rocket) {
+        this._launchEmitter = this.add.particles(rocket.x, rocket.y + 36, 'spark_pixel', {
+          speedX: { min: -35, max: 35 },
+          speedY: { min: 180, max: 380 },   // downward exhaust (positive Y = down)
+          quantity: 5,
+          frequency: 25,
+          lifespan: 550,
+          alpha: { start: 1, end: 0 },
+          scale: { start: 2.5, end: 0.4 },
+          tint: [0xff8800, 0xffdd00, 0xff4400, 0xffffff, 0xff6600],
+        }).setDepth(88);
+      }
+    });
+
+    // ── Step 4 — Camera detach + pan to rocket (t=350ms) ────────────────────
+    this.time.delayedCall(350, () => {
+      if (!this.scene?.isActive()) return;
+      this.cameras.main.stopFollow();
+      if (rocket) {
+        this.cameras.main.pan(rocket.x, rocket.y, 500, 'Quad.InOut');
+      }
+    });
+
+    // ── Step 5 — Zoom out + rocket ascent (t=700ms) ──────────────────────────
+    this.time.delayedCall(700, () => {
+      if (!this.scene?.isActive()) return;
+      this.cameras.main.zoomTo(0.6, 1800, 'Quad.Out');
+
+      if (rocket) {
+        this.tweens.add({
+          targets: rocket,
+          y: rocket.y - 580,
+          duration: 2200,
+          ease: 'Quad.In',
+          onUpdate: () => {
+            // Keep exhaust emitter attached to rocket bottom
+            if (this._launchEmitter && rocket.active) {
+              this._launchEmitter.setPosition(rocket.x, rocket.y + 36);
+            }
+          },
+        });
+      }
+    });
+
+    // ── Step 6 — Under-the-wire toast (t=1000ms) ─────────────────────────────
+    if (underTheWire) {
+      this.time.delayedCall(1000, () => {
+        if (!this.scene?.isActive()) return;
+        this.registry.set('hudToast', `UNDER THE WIRE|${Date.now()}`);
+      });
+    }
+
+    // ── Step 7 — Final shake (t=2600ms) ──────────────────────────────────────
+    this.time.delayedCall(2600, () => {
+      if (!this.scene?.isActive()) return;
+      this.cameras.main.shake(600, 0.02);
+    });
+
+    // ── Step 8 — Fade to black + transition (t=3200ms) ───────────────────────
+    this.time.delayedCall(3200, () => {
+      if (!this.scene?.isActive()) return;
+      this.cameras.main.fade(700, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this._launchEmitter?.destroy();
+        this._launchEmitter = null;
+        this.endRun('victory', { underTheWire });
+      });
+    });
   }
 }

--- a/src/scenes/outro.js
+++ b/src/scenes/outro.js
@@ -30,6 +30,7 @@ export default class Outro extends Phaser.Scene {
 
   init(data) {
     this.state = data.state || "death"; // "death" | "timeout" | "victory"
+    this.underTheWire = data.underTheWire ?? false;
   }
 
   create() {
@@ -145,8 +146,26 @@ export default class Outro extends Phaser.Scene {
       .setTint(0x888888)
       .setCenterAlign();
 
-    this.addDivider(230);
-    this.addStatsRow(260);
+    if (this.underTheWire) {
+      this.add
+        .bitmapText(this.cx, 208, "default", "** UNDER THE WIRE -- < 2 MIN REMAINING **", 14)
+        .setOrigin(0.5)
+        .setTint(0xff4444)
+        .setCenterAlign();
+    }
+
+    const dividerY  = this.underTheWire ? 254 : 230;
+    const statsY    = this.underTheWire ? 284 : 260;
+
+    this.addDivider(dividerY);
+    this.addStatsRow(statsY);
+
+    // SYSTEMS INSTALLED — victory screen only
+    const systems = this.registry.get("systemsInstalled") ?? 0;
+    this.add
+      .bitmapText(this.cx, statsY + 55, "default", `SYSTEMS INSTALLED: ${systems} / 4`, 18)
+      .setOrigin(0.5)
+      .setTint(0x00eeff);
   }
 
   // ─── Shared layout helpers ──────────────────────────────────────────────────
@@ -196,7 +215,7 @@ export default class Outro extends Phaser.Scene {
       .setTint(0x4fffaa);
 
     const stateLabel = this.state === "victory"
-      ? `Escaped Hurricane Kendra in ${this.formatTime(this.elapsed)} with ${this.xp} XP.`
+      ? `Escaped Hurricane Kendra in ${this.formatTime(this.elapsed)} with ${this.xp} XP.${this.underTheWire ? ' Under the Wire!' : ''}`
       : this.state === "timeout"
         ? `Survived ${this.formatTime(this.elapsed)} before Hurricane Kendra made landfall.`
         : `Survived ${this.formatTime(this.elapsed)} and earned ${this.xp} XP before going down.`;

--- a/tests/launch-sequence.test.js
+++ b/tests/launch-sequence.test.js
@@ -1,0 +1,257 @@
+/**
+ * Launch Sequence Tests (Phase 6.1)
+ *
+ * Tests for:
+ *   - Under-the-wire detection logic (timeLeft < 120)
+ *   - endRun() options passing to outro scene
+ *   - _launching guard preventing double-endRun on timer expiry
+ *   - OutroScene init() underTheWire state assignment
+ *   - Share card text construction for victory state
+ *
+ * No Phaser import — all logic is tested via plain-object mocks.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Group 1 — Under-the-wire detection logic ─────────────────────────────────
+//
+// Inlined from src/scenes/game.js finishScene() — keep in sync:
+//   const underTheWire = timeLeft < 120;
+
+const isUnderTheWire = (timeLeft) => timeLeft < 120;
+
+describe('Under-the-wire detection', () => {
+  it('timeLeft=119 → underTheWire is true', () => {
+    expect(isUnderTheWire(119)).toBe(true);
+  });
+
+  it('timeLeft=120 → underTheWire is false (boundary: exactly 2 min is NOT under the wire)', () => {
+    expect(isUnderTheWire(120)).toBe(false);
+  });
+
+  it('timeLeft=0 → underTheWire is true (timer expired with no time left)', () => {
+    expect(isUnderTheWire(0)).toBe(true);
+  });
+
+  it('timeLeft=3600 → underTheWire is false (full time remaining)', () => {
+    expect(isUnderTheWire(3600)).toBe(false);
+  });
+});
+
+// ── Group 2 — endRun() options passing ───────────────────────────────────────
+//
+// Inlined from src/scenes/game.js endRun():
+//   endRun(state, options = {}) {
+//     this.scene.stop("hud");
+//     this.scene.start("outro", { state, underTheWire: options.underTheWire ?? false });
+//   }
+
+function makeGameScene() {
+  const scene = {
+    _launching: false,
+    scene: {
+      stop: vi.fn(),
+      start: vi.fn(),
+    },
+  };
+
+  scene.endRun = function (state, options = {}) {
+    this.scene.stop('hud');
+    this.scene.start('outro', { state, underTheWire: options.underTheWire ?? false });
+  };
+
+  return scene;
+}
+
+describe('endRun() options passing', () => {
+  it('victory + underTheWire:true → scene.start called with { state:"victory", underTheWire:true }', () => {
+    const scene = makeGameScene();
+    scene.endRun('victory', { underTheWire: true });
+
+    expect(scene.scene.stop).toHaveBeenCalledWith('hud');
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', {
+      state: 'victory',
+      underTheWire: true,
+    });
+  });
+
+  it('victory + empty options → underTheWire defaults to false', () => {
+    const scene = makeGameScene();
+    scene.endRun('victory', {});
+
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', {
+      state: 'victory',
+      underTheWire: false,
+    });
+  });
+
+  it('timeout with no options arg → { state:"timeout", underTheWire:false }', () => {
+    const scene = makeGameScene();
+    scene.endRun('timeout');
+
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', {
+      state: 'timeout',
+      underTheWire: false,
+    });
+  });
+
+  it('victory + underTheWire:false → underTheWire is false (explicit false preserved)', () => {
+    const scene = makeGameScene();
+    scene.endRun('victory', { underTheWire: false });
+
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', {
+      state: 'victory',
+      underTheWire: false,
+    });
+  });
+});
+
+// ── Group 3 — _launching guard ───────────────────────────────────────────────
+//
+// Inlined from src/scenes/game.js listenForGameOver():
+//   const onExpired = (parent, value) => {
+//     if (this._launching) return;
+//     if (value === true) this.endRun("timeout");
+//   };
+
+function makeGameSceneWithGuard() {
+  const scene = makeGameScene();
+
+  // Mirror the onExpired closure from listenForGameOver(), bound to `scene`
+  scene._onExpired = function (parent, value) {
+    if (scene._launching) return;
+    if (value === true) scene.endRun('timeout');
+  };
+
+  return scene;
+}
+
+describe('_launching guard in timerExpired handler', () => {
+  it('_launching=true → endRun is NOT called when timer fires', () => {
+    const scene = makeGameSceneWithGuard();
+    scene._launching = true;
+
+    scene._onExpired(null, true);
+
+    expect(scene.scene.start).not.toHaveBeenCalled();
+  });
+
+  it('_launching=false → endRun("timeout") IS called when timer fires', () => {
+    const scene = makeGameSceneWithGuard();
+    scene._launching = false;
+
+    scene._onExpired(null, true);
+
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', {
+      state: 'timeout',
+      underTheWire: false,
+    });
+  });
+
+  it('_launching=false but value=false → endRun is NOT called (guard on value)', () => {
+    const scene = makeGameSceneWithGuard();
+    scene._launching = false;
+
+    scene._onExpired(null, false);
+
+    expect(scene.scene.start).not.toHaveBeenCalled();
+  });
+});
+
+// ── Group 4 — OutroScene init() underTheWire handling ────────────────────────
+//
+// Inlined from src/scenes/outro.js init():
+//   init(data) {
+//     this.state = data.state || "death";
+//     this.underTheWire = data.underTheWire ?? false;
+//   }
+
+function makeOutroScene() {
+  const scene = {
+    state: null,
+    underTheWire: null,
+  };
+
+  scene.init = function (data) {
+    this.state = data.state || 'death';
+    this.underTheWire = data.underTheWire ?? false;
+  };
+
+  return scene;
+}
+
+describe('OutroScene init() — underTheWire assignment', () => {
+  it('{ state:"victory", underTheWire:true } → this.underTheWire === true', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'victory', underTheWire: true });
+    expect(scene.underTheWire).toBe(true);
+  });
+
+  it('{ state:"victory", underTheWire:false } → this.underTheWire === false', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'victory', underTheWire: false });
+    expect(scene.underTheWire).toBe(false);
+  });
+
+  it('{ state:"victory" } (key absent) → this.underTheWire defaults to false', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'victory' });
+    expect(scene.underTheWire).toBe(false);
+  });
+
+  it('{ state:"death" } → this.underTheWire is false (non-victory state)', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'death' });
+    expect(scene.underTheWire).toBe(false);
+  });
+});
+
+// ── Group 5 — Share card text ─────────────────────────────────────────────────
+//
+// Inlined from src/scenes/outro.js addShareCard():
+//   const stateLabel = this.state === "victory"
+//     ? `Escaped Hurricane Kendra in ${this.formatTime(this.elapsed)} with ${this.xp} XP.${this.underTheWire ? ' Under the Wire!' : ''}`
+//     : ...;
+
+function buildShareCardText(state, underTheWire, elapsed, xp) {
+  const formatTime = (seconds) => {
+    const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+    const s = (seconds % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  };
+
+  if (state === 'victory') {
+    return `Escaped Hurricane Kendra in ${formatTime(elapsed)} with ${xp} XP.${underTheWire ? ' Under the Wire!' : ''}`;
+  } else if (state === 'timeout') {
+    return `Survived ${formatTime(elapsed)} before Hurricane Kendra made landfall.`;
+  } else {
+    return `Survived ${formatTime(elapsed)} and earned ${xp} XP before going down.`;
+  }
+}
+
+describe('Share card text — Under the Wire suffix', () => {
+  it('victory + underTheWire:true → text contains "Under the Wire!"', () => {
+    const text = buildShareCardText('victory', true, 3480, 90);
+    expect(text).toContain('Under the Wire!');
+  });
+
+  it('victory + underTheWire:false → text does NOT contain "Under the Wire!"', () => {
+    const text = buildShareCardText('victory', false, 3480, 90);
+    expect(text).not.toContain('Under the Wire!');
+  });
+
+  it('victory + underTheWire:true → text still contains escape narrative prefix', () => {
+    const text = buildShareCardText('victory', true, 3480, 90);
+    expect(text).toContain('Escaped Hurricane Kendra in');
+  });
+
+  it('victory + underTheWire:false → text still contains escape narrative prefix', () => {
+    const text = buildShareCardText('victory', false, 3480, 90);
+    expect(text).toContain('Escaped Hurricane Kendra in');
+  });
+
+  it('non-victory state (timeout) → text never contains "Under the Wire!" regardless of flag', () => {
+    const text = buildShareCardText('timeout', true, 1800, 0);
+    expect(text).not.toContain('Under the Wire!');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the one-line `finishScene()` placeholder with a 4-second staged cinematic. The rocket launch now feels earned.

**Cinematic beats:**
1. **t=0ms** — Player locked, orange ignition flash + 300ms shake
2. **t=100ms** — Engine exhaust particle emitter spawns at rocket bottom (`spark_pixel`, depth 88, orange/yellow/white tint, tracks rocket via `onUpdate`)
3. **t=350ms** — Camera detaches from player, pans to rocket (500ms Quad.InOut)
4. **t=700ms** — Camera zooms out to 0.6× (1800ms) while rocket ascends 580px (2200ms Quad.In)
5. **t=1000ms** — "UNDER THE WIRE" HUD toast fires if `timeLeft < 120`
6. **t=2600ms** — Final shake (600ms, 0.02)
7. **t=3200ms** — Fade to black → `endRun("victory", { underTheWire })`

**Under-the-Wire achievement** (`timeLeft < 120s` at launch):
- HUD toast during cinematic
- Red badge on OutroScene victory screen: `** UNDER THE WIRE -- < 2 MIN REMAINING **`
- Share card text appends "Under the Wire!"

**Other Outro improvements:**
- Victory screen always shows `SYSTEMS INSTALLED: 4 / 4` in cyan
- Y positions shift dynamically to accommodate the achievement badge

**Guards & safety:**
- `_launching` flag blocks `timerExpired` from firing a `endRun("timeout")` during the cinematic
- All `delayedCall` callbacks check `scene.isActive()` before executing

## Test plan

- [ ] Install all 4 systems, press E at rocket → cinematic plays (~4s), outro shows "JUAN ESCAPES"
- [ ] Launch with < 2 min remaining → "UNDER THE WIRE" toast fires + badge on outro
- [ ] Launch with > 2 min remaining → no badge on outro
- [ ] Timer hits 0:00 during cinematic → `_launching` guard prevents double endRun
- [ ] `npm test` — 1857/1857 passing

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)