### PR TITLE
feat(outro): end-of-run share card with stats overlay (#14)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -206,7 +206,7 @@ Each task is small enough to fit in a single Claude Code session.
   - Screen fades to EndRunScreen with WIN state
   - "Under-the-Wire" achievement if < 2 min remaining
 
-- ⏳ **6.2 End-of-run share card** [#14](https://github.com/m3ssana/swampfire/issues/14)
+- ✅ **6.2 End-of-run share card** [#14](https://github.com/m3ssana/swampfire/issues/14)
   - Styled canvas overlay with run stats
   - Time remaining, XP total, items found, combos hit, zones visited
   - "Copy to clipboard" or "Download as image" button

--- a/src/gameobjects/combo_tracker.js
+++ b/src/gameobjects/combo_tracker.js
@@ -57,6 +57,10 @@ export default class ComboTracker {
     this._frenzyActive = false;
     this._comboText    = null;
 
+    // Run-lifetime stats — survive reset() so they persist to the end-of-run share card
+    this._peakCombo   = 0;
+    this._frenzyCount = 0;
+
     scene.events.once('shutdown', this.destroy, this);
   }
 
@@ -73,6 +77,7 @@ export default class ComboTracker {
    */
   onLoot(x, y) {
     this._count++;
+    if (this._count > this._peakCombo) this._peakCombo = this._count;
     this._restartWindowTimer();
 
     const level = LEVELS[Math.min(this._count, LEVELS.length - 1)];
@@ -92,6 +97,12 @@ export default class ComboTracker {
   getMultiplier() {
     return this._frenzyActive ? FRENZY_MULT : 1.0;
   }
+
+  /** Returns the highest loot streak count reached during this run. */
+  getPeakCombo() { return this._peakCombo; }
+
+  /** Returns the number of distinct FRENZY activations during this run. */
+  getFrenzyCount() { return this._frenzyCount; }
 
   /**
    * Hard-resets all streak state. Call on player death so the combo does
@@ -172,6 +183,7 @@ export default class ComboTracker {
    */
   _triggerFrenzy() {
     this._frenzyActive = true;
+    this._frenzyCount++;
 
     // Shake: heavier than install (0.008) and death (0.012)
     this.scene.cameras.main.shake(400, 0.018);

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -46,6 +46,10 @@ export default class Game extends Phaser.Scene {
     // Used by showXPGain() to merge rapid same-context grants into one popup
     this._xpPending = {};
 
+    // Zone visit tracking — persists across mid-run deaths via registry
+    const seededZones = this.registry.get('visitedZones') ?? [0];
+    this._visitedZones = new Set(seededZones);
+
     this.addMap();
     this.addPlayer();
     this.addCollisions();
@@ -209,8 +213,20 @@ export default class Game extends Phaser.Scene {
     Stop the HUD and transition to the end-run screen with the given state.
   */
   endRun(state, options = {}) {
+    const peakCombo    = this.comboTracker?.getPeakCombo()   ?? 0;
+    const frenzyCount  = this.comboTracker?.getFrenzyCount() ?? 0;
+    const zonesVisited = this._visitedZones?.size            ?? 1;
+    const itemsFound   = (this.registry.get('inventory') ?? []).length;
+
     this.scene.stop("hud");
-    this.scene.start("outro", { state, underTheWire: options.underTheWire ?? false });
+    this.scene.start("outro", {
+      state,
+      underTheWire: options.underTheWire ?? false,
+      peakCombo,
+      frenzyCount,
+      zonesVisited,
+      itemsFound,
+    });
   }
 
   // ─── HUD ───────────────────────────────────────────────────────────────────
@@ -508,6 +524,8 @@ export default class Game extends Phaser.Scene {
       // ── Swap zones ──────────────────────────────────────────────────────────
       this.zone.destroyCurrentZone();
       this.zone.loadZone(targetZoneId, sourceZoneId);
+      this._visitedZones.add(targetZoneId);
+      this.registry.set('visitedZones', [...this._visitedZones]);
 
       // ── Reposition player ───────────────────────────────────────────────────
       const entry = this.zone.getEntryPoint(sourceZoneId);

--- a/src/scenes/outro.js
+++ b/src/scenes/outro.js
@@ -29,8 +29,14 @@ export default class Outro extends Phaser.Scene {
   }
 
   init(data) {
-    this.state = data.state || "death"; // "death" | "timeout" | "victory"
+    this.state        = data.state        || "death"; // "death" | "timeout" | "victory"
     this.underTheWire = data.underTheWire ?? false;
+    this.peakCombo    = data.peakCombo    ?? 0;
+    this.frenzyCount  = data.frenzyCount  ?? 0;
+    this.zonesVisited = data.zonesVisited ?? 1;
+    this.itemsFound   = data.itemsFound   ?? 0;
+    this.deathMsg     = null; // set by showDeathScreen() for use in share card
+    this._feedbackText = null;
   }
 
   create() {
@@ -79,10 +85,10 @@ export default class Outro extends Phaser.Scene {
       .setOrigin(0.5)
       .setTint(0x888888);
 
-    // Random Florida Man headline
-    const msg = Phaser.Utils.Array.GetRandom(DEATH_MESSAGES);
+    // Random Florida Man headline — stored for share card
+    this.deathMsg = Phaser.Utils.Array.GetRandom(DEATH_MESSAGES);
     this.add
-      .bitmapText(this.cx, 128, "default", msg, 16)
+      .bitmapText(this.cx, 128, "default", this.deathMsg, 16)
       .setOrigin(0.5, 0)
       .setTint(0xffffff)
       .setCenterAlign();
@@ -226,10 +232,191 @@ export default class Outro extends Phaser.Scene {
       .setTint(0xdddddd)
       .setCenterAlign();
 
+    // Share buttons — [C] COPY IMAGE only when Clipboard API is available
+    const canCopy = typeof ClipboardItem !== 'undefined';
+    const btnY = cardY + 82;
+
+    if (canCopy) {
+      this.add
+        .bitmapText(this.cx - 80, btnY, "default", "[C] COPY IMAGE", 10)
+        .setOrigin(0.5)
+        .setTint(0x4fffaa);
+      this.input.keyboard.on("keydown-C", this._copyCard, this);
+    }
+
     this.add
-      .bitmapText(this.cx, cardY + 68, "default", "[ SHARE CARD -- COPY / DOWNLOAD IN PHASE 6 ]", 10)
+      .bitmapText(canCopy ? this.cx + 80 : this.cx, btnY, "default", "[D] SAVE IMAGE", 10)
       .setOrigin(0.5)
-      .setTint(0x444444);
+      .setTint(0x4fffaa);
+
+    this.input.keyboard.on("keydown-D", this._downloadCard, this);
+  }
+
+  // ─── Share card implementation ───────────────────────────────────────────────
+
+  /*
+    Captures the current Phaser frame via renderer.snapshotArea(), then draws a
+    640×360 styled card on an offscreen Canvas2D element. Delivers the canvas to
+    the callback — called once the snapshot is ready (next frame).
+  */
+  _buildShareCanvas(callback) {
+    const { width, height } = this.sys.game.config;
+
+    this.sys.game.renderer.snapshotArea(0, 0, width, height, (phaserImage) => {
+      const W = 640, H = 360;
+      const canvas  = document.createElement('canvas');
+      canvas.width  = W;
+      canvas.height = H;
+      const ctx = canvas.getContext('2d');
+
+      // Background: dark solid matching end state
+      ctx.fillStyle = this.state === 'victory' ? '#051a05'
+                    : this.state === 'timeout'  ? '#05050a'
+                    : '#1a0505';
+      ctx.fillRect(0, 0, W, H);
+
+      // Phaser frame composited at reduced opacity for context
+      ctx.globalAlpha = 0.45;
+      ctx.drawImage(phaserImage, 0, 0, W, H);
+      ctx.globalAlpha = 1.0;
+
+      // Dark overlay for text readability
+      ctx.fillStyle = 'rgba(0,0,0,0.60)';
+      ctx.fillRect(0, 0, W, H);
+
+      ctx.textAlign    = 'center';
+      ctx.textBaseline = 'top';
+
+      // ── Header ──
+      ctx.font      = 'bold 18px monospace';
+      ctx.fillStyle = '#4fffaa';
+      ctx.fillText('SWAMPFIRE PROTOCOL', W / 2, 16);
+
+      // ── State line ──
+      const stateStr = this.state === 'victory' ? 'JUAN ESCAPES'
+                     : this.state === 'timeout'  ? 'HURRICANE KENDRA LANDS'
+                     : 'JUAN IS DOWN';
+      ctx.font      = 'bold 26px monospace';
+      ctx.fillStyle = this.state === 'victory' ? '#4fffaa'
+                    : this.state === 'timeout'  ? '#ff6633'
+                    : '#ff3333';
+      ctx.fillText(stateStr, W / 2, 44);
+
+      // ── Death headline (death state only) ──
+      if (this.state === 'death' && this.deathMsg) {
+        ctx.font      = '12px monospace';
+        ctx.fillStyle = '#dddddd';
+        const lines = this.deathMsg.split('\n');
+        lines.forEach((line, i) => ctx.fillText(line.trim(), W / 2, 86 + i * 16));
+      }
+
+      // ── Divider ──
+      ctx.strokeStyle = '#333333';
+      ctx.lineWidth   = 1;
+      ctx.beginPath();
+      ctx.moveTo(60, 136);
+      ctx.lineTo(W - 60, 136);
+      ctx.stroke();
+
+      // ── Primary stats row ──
+      const statsY = 148;
+      const statCols = [
+        { x: 160, label: 'TIME SURVIVED', value: this.formatTime(this.elapsed) },
+        { x: 320, label: 'XP EARNED',     value: String(this.xp) },
+        { x: 480, label: 'HP REMAINING',  value: `${this.hp} / 3` },
+      ];
+      ctx.font      = '10px monospace';
+      ctx.fillStyle = '#888888';
+      statCols.forEach(({ x, label }) => ctx.fillText(label, x, statsY));
+      ctx.font      = 'bold 20px monospace';
+      ctx.fillStyle = '#ffffff';
+      statCols.forEach(({ x, value }) => ctx.fillText(value, x, statsY + 14));
+
+      // ── Extra stats row ──
+      const extY = 218;
+      const extraCols = [
+        { x: 120, label: 'ITEMS FOUND',              value: String(this.itemsFound) },
+        { x: 270, label: 'PEAK COMBO',               value: String(this.peakCombo) },
+        { x: 410, label: `FRENZY ×${this.frenzyCount}`, value: String(this.frenzyCount) },
+        { x: 550, label: 'ZONES',                    value: `${this.zonesVisited} / 5` },
+      ];
+      ctx.font      = '10px monospace';
+      ctx.fillStyle = '#888888';
+      extraCols.forEach(({ x, label }) => ctx.fillText(label, x, extY));
+      ctx.font      = 'bold 16px monospace';
+      ctx.fillStyle = '#ffffff';
+      extraCols.forEach(({ x, value }) => ctx.fillText(value, x, extY + 14));
+
+      // ── Footer ──
+      ctx.font      = '11px monospace';
+      ctx.fillStyle = '#4fffaa';
+      ctx.fillText('#SwampfireProtocol', W / 2, H - 20);
+
+      callback(canvas);
+    });
+  }
+
+  /*
+    Copies the share card to the system clipboard as a PNG image.
+    Requires user gesture (keyboard press) and HTTPS.
+    Shows "COPIED!" or "COPY FAILED" feedback.
+  */
+  _copyCard() {
+    this._buildShareCanvas((canvas) => {
+      canvas.toBlob(async (blob) => {
+        if (!blob) { this._showShareFeedback('EXPORT FAILED'); return; }
+        try {
+          await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+          this._showShareFeedback('COPIED!');
+        } catch (_err) {
+          this._showShareFeedback('COPY FAILED');
+        }
+      }, 'image/png');
+    });
+  }
+
+  /*
+    Downloads the share card as swampfire-run.png.
+    Uses canvas.toBlob() + a temporary anchor element.
+  */
+  _downloadCard() {
+    this._buildShareCanvas((canvas) => {
+      canvas.toBlob((blob) => {
+        if (!blob) { this._showShareFeedback('EXPORT FAILED'); return; }
+        const url = URL.createObjectURL(blob);
+        const a   = document.createElement('a');
+        a.href     = url;
+        a.download = 'swampfire-run.png';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+      }, 'image/png');
+    });
+  }
+
+  /*
+    Shows brief feedback text that fades out after 1.5s.
+    Destroys any prior feedback text before creating a new one.
+  */
+  _showShareFeedback(msg) {
+    this._feedbackText?.destroy();
+    const text = this.add
+      .bitmapText(this.cx, 358, "default", msg, 14)
+      .setOrigin(0.5)
+      .setTint(0x4fffaa);
+    this._feedbackText = text;
+
+    this.tweens.add({
+      targets:  text,
+      alpha:    { from: 1, to: 0 },
+      duration: 300,
+      delay:    1200,
+      onComplete: () => {
+        if (text?.active) text.destroy();
+        if (this._feedbackText === text) this._feedbackText = null;
+      },
+    });
   }
 
   addRestartPrompt() {

--- a/src/scenes/transition.js
+++ b/src/scenes/transition.js
@@ -292,6 +292,7 @@ export default class Transition extends Phaser.Scene {
     this.registry.set("stormPhase", 1);
     this.registry.set("hudToast", "");
     this.registry.set('npcQuests', { harvey: false, maria: false, dale: false, reeves: false });
+    this.registry.set("visitedZones", [0]); // zone 0 is always the starting zone
 
     this.cameras.main.fade(300, 0, 0, 0);
     this.cameras.main.once("camerafadeoutcomplete", () => {

--- a/tests/share-card.test.js
+++ b/tests/share-card.test.js
@@ -1,0 +1,426 @@
+/**
+ * Share Card Tests (Phase 6.2)
+ *
+ * Tests for:
+ *   - ComboTracker peak combo tracking across multiple loots
+ *   - ComboTracker frenzy count distinct activations
+ *   - Peak / frenzy stats survive reset() (mid-run death) but reset on destroy()
+ *   - Zone visit deduplication via Set semantics
+ *   - endRun() passes all 4 stats fields to OutroScene
+ *   - OutroScene init() safe defaults for all stat fields
+ *   - ClipboardItem guard — copy button rendered only when API is available
+ *
+ * No Phaser import — all logic is tested via plain-object mocks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Group 1 — ComboTracker peak combo tracking ────────────────────────────────
+//
+// Inlined from src/gameobjects/combo_tracker.js:
+//   this._peakCombo = 0;
+//   onLoot(x, y) { this._count++; if (this._count > this._peakCombo) this._peakCombo = this._count; ... }
+//   getPeakCombo() { return this._peakCombo; }
+
+function makeComboTracker() {
+  return {
+    _count: 0,
+    _peakCombo: 0,
+    _frenzyCount: 0,
+    _frenzyActive: false,
+
+    onLoot() {
+      this._count++;
+      if (this._count > this._peakCombo) this._peakCombo = this._count;
+      // Frenzy triggers at count >= 5 (first time only)
+      if (this._count >= 5 && !this._frenzyActive) {
+        this._frenzyActive = true;
+        this._frenzyCount++;
+      }
+    },
+
+    reset() {
+      // Streak resets on death, but lifetime stats (_peakCombo, _frenzyCount) survive
+      this._count = 0;
+      this._frenzyActive = false;
+    },
+
+    getPeakCombo()   { return this._peakCombo; },
+    getFrenzyCount() { return this._frenzyCount; },
+  };
+}
+
+describe('ComboTracker — peak combo tracking', () => {
+  it('getPeakCombo() starts at 0 before any loots', () => {
+    const tracker = makeComboTracker();
+    expect(tracker.getPeakCombo()).toBe(0);
+  });
+
+  it('getPeakCombo() equals 1 after a single loot', () => {
+    const tracker = makeComboTracker();
+    tracker.onLoot();
+    expect(tracker.getPeakCombo()).toBe(1);
+  });
+
+  it('getPeakCombo() tracks the highest count reached', () => {
+    const tracker = makeComboTracker();
+    tracker.onLoot();
+    tracker.onLoot();
+    tracker.onLoot(); // count = 3, peak = 3
+    tracker.reset();  // count resets to 0, peak stays at 3
+    tracker.onLoot(); // count = 1, peak still 3
+    expect(tracker.getPeakCombo()).toBe(3);
+  });
+
+  it('getPeakCombo() keeps rising when streak continues past prior peak', () => {
+    const tracker = makeComboTracker();
+    tracker.onLoot();
+    tracker.onLoot(); // peak = 2
+    tracker.reset();
+    tracker.onLoot();
+    tracker.onLoot();
+    tracker.onLoot(); // count = 3 > prior peak 2, peak becomes 3
+    expect(tracker.getPeakCombo()).toBe(3);
+  });
+
+  it('getPeakCombo() never decreases on reset()', () => {
+    const tracker = makeComboTracker();
+    for (let i = 0; i < 7; i++) tracker.onLoot(); // peak = 7
+    tracker.reset();
+    expect(tracker.getPeakCombo()).toBe(7);
+    tracker.reset();
+    expect(tracker.getPeakCombo()).toBe(7);
+  });
+});
+
+// ── Group 2 — ComboTracker frenzy count ──────────────────────────────────────
+//
+// Inlined from src/gameobjects/combo_tracker.js _triggerFrenzy():
+//   this._frenzyCount++;   (only when !_frenzyActive, i.e. first time at >=5)
+
+describe('ComboTracker — frenzy count', () => {
+  it('getFrenzyCount() starts at 0', () => {
+    const tracker = makeComboTracker();
+    expect(tracker.getFrenzyCount()).toBe(0);
+  });
+
+  it('reaching 5 loots in a streak increments frenzyCount by 1', () => {
+    const tracker = makeComboTracker();
+    for (let i = 0; i < 5; i++) tracker.onLoot();
+    expect(tracker.getFrenzyCount()).toBe(1);
+  });
+
+  it('frenzy only counts once per active window (loots 6, 7 do not re-trigger)', () => {
+    const tracker = makeComboTracker();
+    for (let i = 0; i < 7; i++) tracker.onLoot();
+    expect(tracker.getFrenzyCount()).toBe(1);
+  });
+
+  it('reset() then 5 more loots yields a second frenzy activation', () => {
+    const tracker = makeComboTracker();
+    for (let i = 0; i < 5; i++) tracker.onLoot(); // 1st frenzy
+    tracker.reset();                               // clears _frenzyActive
+    for (let i = 0; i < 5; i++) tracker.onLoot(); // 2nd frenzy
+    expect(tracker.getFrenzyCount()).toBe(2);
+  });
+
+  it('frenzyCount survives reset() (persists to share card)', () => {
+    const tracker = makeComboTracker();
+    for (let i = 0; i < 5; i++) tracker.onLoot();
+    tracker.reset();
+    expect(tracker.getFrenzyCount()).toBe(1);
+  });
+
+  it('4 loots is not enough to trigger frenzy', () => {
+    const tracker = makeComboTracker();
+    for (let i = 0; i < 4; i++) tracker.onLoot();
+    expect(tracker.getFrenzyCount()).toBe(0);
+  });
+});
+
+// ── Group 3 — Zone visit deduplication ───────────────────────────────────────
+//
+// Inlined from src/scenes/game.js:
+//   this._visitedZones = new Set(seededZones);
+//   transitionToZone: this._visitedZones.add(targetZoneId);
+//                     this.registry.set('visitedZones', [...this._visitedZones]);
+
+function makeZoneTracker(seededZones = [0]) {
+  return {
+    _visitedZones: new Set(seededZones),
+
+    visitZone(id) {
+      this._visitedZones.add(id);
+    },
+
+    getZonesArray() {
+      return [...this._visitedZones];
+    },
+
+    getZoneCount() {
+      return this._visitedZones.size;
+    },
+  };
+}
+
+describe('Zone visit deduplication', () => {
+  it('starts with zone 0 seeded — size is 1', () => {
+    const tracker = makeZoneTracker([0]);
+    expect(tracker.getZoneCount()).toBe(1);
+  });
+
+  it('visiting a new zone increases count', () => {
+    const tracker = makeZoneTracker([0]);
+    tracker.visitZone(1);
+    expect(tracker.getZoneCount()).toBe(2);
+  });
+
+  it('revisiting an already-visited zone does NOT increase count', () => {
+    const tracker = makeZoneTracker([0]);
+    tracker.visitZone(1);
+    tracker.visitZone(1); // duplicate
+    expect(tracker.getZoneCount()).toBe(2);
+  });
+
+  it('visiting all 4 zones (0-3) yields size 4', () => {
+    const tracker = makeZoneTracker([0]);
+    tracker.visitZone(1);
+    tracker.visitZone(2);
+    tracker.visitZone(3);
+    expect(tracker.getZoneCount()).toBe(4);
+  });
+
+  it('zones array spread includes all unique zone IDs', () => {
+    const tracker = makeZoneTracker([0]);
+    tracker.visitZone(2);
+    tracker.visitZone(2);
+    tracker.visitZone(3);
+    const arr = tracker.getZonesArray();
+    expect(arr).toContain(0);
+    expect(arr).toContain(2);
+    expect(arr).toContain(3);
+    expect(arr).toHaveLength(3);
+  });
+
+  it('seeded with multiple zones restores prior session state', () => {
+    const tracker = makeZoneTracker([0, 1, 2]);
+    expect(tracker.getZoneCount()).toBe(3);
+  });
+});
+
+// ── Group 4 — endRun() passes all stats to OutroScene ─────────────────────────
+//
+// Inlined from src/scenes/game.js endRun():
+//   const peakCombo    = this.comboTracker?.getPeakCombo()   ?? 0;
+//   const frenzyCount  = this.comboTracker?.getFrenzyCount() ?? 0;
+//   const zonesVisited = this._visitedZones?.size            ?? 1;
+//   const itemsFound   = (this.registry.get('inventory') ?? []).length;
+//   this.scene.start("outro", { state, underTheWire, peakCombo, frenzyCount, zonesVisited, itemsFound });
+
+function makeGameSceneWithStats({ peakCombo = 0, frenzyCount = 0, zonesVisited = 1, inventory = [] } = {}) {
+  const scene = {
+    _launching: false,
+    comboTracker: {
+      getPeakCombo:   () => peakCombo,
+      getFrenzyCount: () => frenzyCount,
+    },
+    _visitedZones: { size: zonesVisited },
+    registry: {
+      get: (key) => key === 'inventory' ? inventory : null,
+    },
+    scene: {
+      stop:  vi.fn(),
+      start: vi.fn(),
+    },
+  };
+
+  scene.endRun = function (state, options = {}) {
+    const pc   = this.comboTracker?.getPeakCombo()   ?? 0;
+    const fc   = this.comboTracker?.getFrenzyCount() ?? 0;
+    const zv   = this._visitedZones?.size            ?? 1;
+    const inv  = (this.registry.get('inventory') ?? []).length;
+    this.scene.stop('hud');
+    this.scene.start('outro', {
+      state,
+      underTheWire: options.underTheWire ?? false,
+      peakCombo:    pc,
+      frenzyCount:  fc,
+      zonesVisited: zv,
+      itemsFound:   inv,
+    });
+  };
+
+  return scene;
+}
+
+describe('endRun() — stats payload to OutroScene', () => {
+  it('passes peakCombo from comboTracker to outro', () => {
+    const scene = makeGameSceneWithStats({ peakCombo: 7 });
+    scene.endRun('victory', { underTheWire: false });
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      peakCombo: 7,
+    }));
+  });
+
+  it('passes frenzyCount from comboTracker to outro', () => {
+    const scene = makeGameSceneWithStats({ frenzyCount: 3 });
+    scene.endRun('victory', {});
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      frenzyCount: 3,
+    }));
+  });
+
+  it('passes zonesVisited from _visitedZones.size to outro', () => {
+    const scene = makeGameSceneWithStats({ zonesVisited: 4 });
+    scene.endRun('timeout');
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      zonesVisited: 4,
+    }));
+  });
+
+  it('passes itemsFound as inventory length to outro', () => {
+    const scene = makeGameSceneWithStats({ inventory: ['a', 'b', 'c'] });
+    scene.endRun('death', {});
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      itemsFound: 3,
+    }));
+  });
+
+  it('null comboTracker falls back to 0 for both stats', () => {
+    const scene = makeGameSceneWithStats();
+    scene.comboTracker = null;
+    scene.endRun('death');
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      peakCombo:   0,
+      frenzyCount: 0,
+    }));
+  });
+
+  it('null _visitedZones falls back to 1 for zonesVisited', () => {
+    const scene = makeGameSceneWithStats();
+    scene._visitedZones = null;
+    scene.endRun('death');
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      zonesVisited: 1,
+    }));
+  });
+
+  it('null inventory registry value falls back to itemsFound: 0', () => {
+    const scene = makeGameSceneWithStats();
+    scene.registry = { get: () => null };
+    scene.endRun('death');
+    expect(scene.scene.start).toHaveBeenCalledWith('outro', expect.objectContaining({
+      itemsFound: 0,
+    }));
+  });
+});
+
+// ── Group 5 — OutroScene init() safe defaults ─────────────────────────────────
+//
+// Inlined from src/scenes/outro.js init():
+//   this.peakCombo    = data.peakCombo    ?? 0;
+//   this.frenzyCount  = data.frenzyCount  ?? 0;
+//   this.zonesVisited = data.zonesVisited ?? 1;
+//   this.itemsFound   = data.itemsFound   ?? 0;
+
+function makeOutroScene() {
+  const scene = {
+    state: null,
+    underTheWire: null,
+    peakCombo: null,
+    frenzyCount: null,
+    zonesVisited: null,
+    itemsFound: null,
+    deathMsg: null,
+    _feedbackText: null,
+  };
+
+  scene.init = function (data) {
+    this.state        = data.state        || 'death';
+    this.underTheWire = data.underTheWire ?? false;
+    this.peakCombo    = data.peakCombo    ?? 0;
+    this.frenzyCount  = data.frenzyCount  ?? 0;
+    this.zonesVisited = data.zonesVisited ?? 1;
+    this.itemsFound   = data.itemsFound   ?? 0;
+    this.deathMsg     = null;
+    this._feedbackText = null;
+  };
+
+  return scene;
+}
+
+describe('OutroScene init() — stat safe defaults', () => {
+  it('all fields provided → all values stored verbatim', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'victory', underTheWire: true, peakCombo: 6, frenzyCount: 2, zonesVisited: 3, itemsFound: 5 });
+    expect(scene.peakCombo).toBe(6);
+    expect(scene.frenzyCount).toBe(2);
+    expect(scene.zonesVisited).toBe(3);
+    expect(scene.itemsFound).toBe(5);
+  });
+
+  it('peakCombo absent → defaults to 0', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'death' });
+    expect(scene.peakCombo).toBe(0);
+  });
+
+  it('frenzyCount absent → defaults to 0', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'death' });
+    expect(scene.frenzyCount).toBe(0);
+  });
+
+  it('zonesVisited absent → defaults to 1 (at least starting zone)', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'death' });
+    expect(scene.zonesVisited).toBe(1);
+  });
+
+  it('itemsFound absent → defaults to 0', () => {
+    const scene = makeOutroScene();
+    scene.init({ state: 'death' });
+    expect(scene.itemsFound).toBe(0);
+  });
+
+  it('deathMsg always resets to null on init', () => {
+    const scene = makeOutroScene();
+    scene.deathMsg = 'Florida Man';
+    scene.init({ state: 'victory' });
+    expect(scene.deathMsg).toBeNull();
+  });
+
+  it('state missing → defaults to "death"', () => {
+    const scene = makeOutroScene();
+    scene.init({});
+    expect(scene.state).toBe('death');
+  });
+});
+
+// ── Group 6 — ClipboardItem guard ────────────────────────────────────────────
+//
+// Inlined from src/scenes/outro.js addShareCard():
+//   const canCopy = typeof ClipboardItem !== 'undefined';
+//   if (canCopy) { renderCopyButton(); }
+
+function evalClipboardGuard(globalObj = {}) {
+  // Simulate the guard expression from outro.js
+  return typeof globalObj.ClipboardItem !== 'undefined';
+}
+
+describe('ClipboardItem guard — copy button availability', () => {
+  it('ClipboardItem defined → canCopy is true', () => {
+    const env = { ClipboardItem: class {} };
+    expect(evalClipboardGuard(env)).toBe(true);
+  });
+
+  it('ClipboardItem undefined → canCopy is false', () => {
+    const env = {};
+    expect(evalClipboardGuard(env)).toBe(false);
+  });
+
+  it('typeof guard is safe when key is explicitly undefined', () => {
+    const env = { ClipboardItem: undefined };
+    expect(evalClipboardGuard(env)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **ComboTracker** gains run-lifetime `_peakCombo` / `_frenzyCount` tracking (survive `reset()` so mid-run deaths don't wipe the share card data); exposes `getPeakCombo()` + `getFrenzyCount()` getters
- **GameScene** tracks visited zones via a `Set`, persists to registry across zone loads; `endRun()` now forwards `peakCombo`, `frenzyCount`, `zonesVisited`, `itemsFound` to OutroScene
- **TransitionScene** seeds `visitedZones=[0]` alongside other registry state in `loadNext()`
- **OutroScene** replaces the placeholder with a real 640×360 share card: offscreen Canvas2D composited over a Phaser `snapshotArea()` frame; `[C] COPY IMAGE` via `ClipboardItem` (guarded for browser support), `[D] SAVE IMAGE` via `toBlob` + anchor download
- **tests/share-card.test.js** — 35 pure-logic unit tests: combo peak tracking, frenzy count distinct activations, zone visit deduplication, `endRun()` stats payload shape, `OutroScene.init()` safe defaults, `ClipboardItem` guard

## Test plan

- [ ] Run `pnpm test` — all 35 share-card unit tests pass
- [ ] Run `pnpm test` — no regressions in existing test suites (launch-sequence, game-logic, etc.)
- [ ] Run E2E suite — `game-flow.e2e.js` 13/13 still green
- [ ] Build passes: `pnpm run build`
- [ ] Manual: reach OutroScene via death / timeout / victory; verify share card appears with correct stat values
- [ ] Manual: `[D]` downloads a PNG file with correct layout
- [ ] Manual: `[C]` copies image to clipboard (HTTPS / secure context required)
- [ ] Manual: `[C]` copy button is hidden when `ClipboardItem` is unavailable (e.g. `http://` context)
- [ ] Manual: visiting 2+ zones shows correct `zonesVisited` on card
- [ ] Manual: triggering FRENZY shows `frenzyCount >= 1` on card

🤖 Generated with [Claude Code](https://claude.com/claude-code)