### PR TITLE
feat(layout): dark page background, 1280×720 canvas, delete dead CSS (#55 #56 #57)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -9,7 +9,7 @@
 **Title:** Swampfire Protocol
 **Engine:** Phaser 3.80+ (Matter.js physics)
 **Platform:** Desktop browser (Chrome, Firefox, Edge), mobile-responsive
-**Resolution:** 960x640, Phaser.Scale.FIT with CENTER_BOTH
+**Resolution:** 1280x720 (16:9 widescreen), Phaser.Scale.FIT with CENTER_BOTH
 **Genre:** Top-down speed scavenger / countdown action
 **Tone:** Urgent, humid, desperate. Florida swamp noir meets speedrun thriller.
 **Target Session Length:** 55-65 minutes (one sitting, one shot, one hour)
@@ -417,8 +417,8 @@ src/
 ```javascript
 const config = {
   type: Phaser.WEBGL,              // Required for shader pipeline + Light2D
-  width: 960,
-  height: 640,
+  width: 1280,
+  height: 720,
   scale: {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,
@@ -451,6 +451,27 @@ const config = {
   ],
 };
 ```
+
+### 5.2.1 Page Layout
+
+The game canvas is embedded in a dark-themed HTML page that reinforces the swamp atmosphere:
+
+```css
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: #0a0f0a;  /* near-black swamp green */
+  overflow: hidden;            /* prevent scrollbars */
+}
+
+#game-container {
+  border: 1px solid rgba(79, 255, 170, 0.15);   /* faint cyan accent border */
+  border-radius: 2px;
+  box-shadow: 0 0 40px rgba(79, 255, 170, 0.06); /* subtle cyan glow */
+}
+```
+
+**Design rationale:** The dark background (`#0a0f0a`) is near-black with a green undertone that blends with the game's internal background (`0x1a2e1a`). The faint border and glow use the game's cyan HUD accent (`0x4fffaa`) at very low opacity so the canvas feels embedded in the world rather than floating on a blank page. No external CSS file — all styling lives inline in `index.html` for zero-dependency simplicity.
 
 ### 5.3 Scene Management
 
@@ -1229,6 +1250,6 @@ The game is designed to produce moments players naturally want to capture and sh
 1. **Difficulty toggle:** Should there be a "Tourist Mode" with 90-minute timer for accessibility? Current spec is 60 minutes only. Playtesting will determine if this is needed.
 2. **Procedural vs. fixed loot:** Key rocket components have fixed primary locations with randomized backup locations. Consumables (food, medkits) are fully randomized. This balance ensures reliability for speedrunning while maintaining variety.
 3. **Online leaderboard scope:** Local-only leaderboard for v1. Online requires backend infrastructure. Deferred to post-launch.
-4. **Mobile portrait mode:** The spec targets landscape 960x640. Portrait mode (one-handed play) is a stretch goal that requires significant UI reorganization.
+4. **Mobile portrait mode:** The spec targets landscape 1280x720 (16:9). Portrait mode (one-handed play) is a stretch goal that requires significant UI reorganization.
 5. **Accessibility:** Colorblind mode for the progress ring and item borders. Screen reader support for death messages. Remappable controls. These should be prioritized before launch.
 6. **Monetization:** Not in scope for v1. The game is free. If monetization is needed: cosmetic skins for Juan (Florida Man costume, NASA jumpsuit, gator hunter outfit) or alternate death message packs.

--- a/TODO.md
+++ b/TODO.md
@@ -220,6 +220,23 @@ Each task is small enough to fit in a single Claude Code session.
 
 ---
 
+## Phase 7 -- Polish + Presentation
+
+- ✅ **7.1 Dark page background + canvas framing** [#55](https://github.com/m3ssana/swampfire/issues/55)
+  - Replace white page background with near-black swamp green (`#0a0f0a`)
+  - Add subtle cyan border/glow on `#game-container` matching HUD accent (`0x4fffaa`)
+  - Set `overflow: hidden` on body to prevent scrollbars
+  - All styling inline in `index.html` — delete unused `public/assets/css/styles.css`
+
+- ✅ **7.2 Upgrade resolution to 1280×720** [#56](https://github.com/m3ssana/swampfire/issues/56)
+  - Changed `width: 960, height: 640` → `width: 1280, height: 720` in `src/main.js`
+  - 16:9 fills widescreen monitors with minimal letterboxing
+
+- ✅ **7.3 Delete unused styles.css** [#57](https://github.com/m3ssana/swampfire/issues/57)
+  - `public/assets/css/styles.css` was never linked in `index.html` — removed
+
+---
+
 ## Bugs
 
 Bugs are tracked here alongside their GitHub issue. When a bug is reported:

--- a/index.html
+++ b/index.html
@@ -7,10 +7,17 @@
     <title>Swampfire Protocol</title>
 
     <style>
-        /* reset CSS */
         html, body {
             margin: 0;
             padding: 0;
+            background-color: #0a0f0a; /* near-black swamp green */
+            overflow: hidden;          /* prevent scrollbars */
+        }
+
+        #game-container {
+            border: 1px solid rgba(79, 255, 170, 0.15);    /* faint cyan accent border */
+            border-radius: 2px;
+            box-shadow: 0 0 40px rgba(79, 255, 170, 0.06); /* subtle cyan glow */
         }
     </style>
 </head>

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -1,8 +1,0 @@
-body,html {
-    margin: 0px;
-    position: relative;
-    background-color: #008080;
-}
-canvas {
-    margin: auto;
-}

--- a/src/main.js
+++ b/src/main.js
@@ -8,8 +8,8 @@ import HUD from "./scenes/hud";
 import PhaserMatterCollisionPlugin from "phaser-matter-collision-plugin";
 
 const config = {
-  width: 960,
-  height: 640,
+  width: 1280,
+  height: 720,
   scale: {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,


### PR DESCRIPTION
## Summary

- **Dark page background** — `#0a0f0a` (near-black swamp green) replaces the default white; `#game-container` gets a subtle cyan border (`rgba(79,255,170,0.15)`) and glow (`box-shadow`); `overflow: hidden` prevents scrollbars
- **1280×720 canvas** — upgraded from 960×640 (3:2) to 1280×720 (16:9); `FIT + CENTER_BOTH` handles responsive scaling automatically; ~78% more pixel area, fills widescreen monitors with minimal letterboxing
- **Delete `styles.css`** — was never linked in `index.html`; all page styling now lives inline
- **SPEC.md updated** — resolution references, config block, new section 5.2.1 Page Layout

## Test plan

- [ ] `pnpm test` — all unit tests pass, no regressions
- [ ] `pnpm run build` — clean build
- [ ] Manual: page background is dark (#0a0f0a), not white
- [ ] Manual: canvas has subtle cyan border/glow
- [ ] Manual: no scrollbars on the page
- [ ] Manual: canvas is noticeably larger than before
- [ ] Manual: HUD elements correctly positioned (timer centered, XP top-left, hearts bottom-left, rocket panel top-right)
- [ ] Manual: Transition scene phases render correctly at 1280×720
- [ ] Manual: share card [D] download still generates a PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)