### PR TITLE
fix(launch): replace camerafadeoutcomplete with delayedCall to prevent lockup (#59)

### DIFF
--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -646,14 +646,21 @@ export default class Game extends Phaser.Scene {
     });
 
     // ── Step 8 — Fade to black + transition (t=3200ms) ───────────────────────
+    //
+    // Use a delayedCall timed to the fade duration rather than the
+    // 'camerafadeoutcomplete' event. After chaining flash → shake → pan →
+    // zoom → shake, Phaser's camera effect pipeline can silently drop the
+    // event, leaving endRun() unreachable and the game locked on black.
     this.time.delayedCall(3200, () => {
       if (!this.scene?.isActive()) return;
       this.cameras.main.fade(700, 0, 0, 0);
-      this.cameras.main.once('camerafadeoutcomplete', () => {
-        this._launchEmitter?.destroy();
-        this._launchEmitter = null;
-        this.endRun('victory', { underTheWire });
-      });
+    });
+
+    this.time.delayedCall(3200 + 750, () => {
+      if (!this.scene?.isActive()) return;
+      this._launchEmitter?.destroy();
+      this._launchEmitter = null;
+      this.endRun('victory', { underTheWire });
     });
   }
 }


### PR DESCRIPTION
## Problem

After the rocket launch cinematic, the game locks up on a black screen and never transitions to OutroScene. Root cause: `cameras.main.once('camerafadeoutcomplete', ...)` is silently dropped by Phaser after chaining 5 camera effects in sequence (flash → shake → pan → zoom → shake). With the event never firing, `endRun()` is never called.

This is the same class of bug that caused the zone transition lockup fixed in #24 — `camerafadeincomplete` was replaced with `time.delayedCall(300)` for the same reason.

## Fix

Replace the unreliable camera event listener with a `time.delayedCall` timed to fire 750ms after the 700ms fade starts (50ms buffer):

```js
// Before — unreliable after chained camera effects
this.cameras.main.fade(700, 0, 0, 0);
this.cameras.main.once('camerafadeoutcomplete', () => { this.endRun(...) });

// After — guaranteed to fire
this.cameras.main.fade(700, 0, 0, 0);
this.time.delayedCall(750, () => { this.endRun(...) });
```

## Test plan

- [ ] `pnpm test` — all unit tests pass
- [ ] `pnpm run build` — clean build
- [ ] Manual: install all 4 rocket systems → press E on rocket → cinematic plays → OutroScene loads with victory state
- [ ] Manual: under-the-wire (< 2 min left) → "UNDER THE WIRE" toast fires during cinematic → victory state shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)