### PR TITLE
fix(launch): restore tween-based camera pan/zoom, add double-launch guard

### DIFF
--- a/src/gameobjects/rocket.js
+++ b/src/gameobjects/rocket.js
@@ -47,9 +47,9 @@ export default class Rocket {
     const n   = this.scene.registry.get('systemsInstalled') ?? 0;
     const inv = this.scene.registry.get('inventory') ?? [];
 
-    // All systems installed — launch!
+    // All systems installed — launch! Guard against double-press during cinematic.
     if (n >= 4) {
-      this.scene.finishScene();
+      if (!this.scene._launching) this.scene.finishScene();
       return;
     }
 

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -650,14 +650,25 @@ export default class Game extends Phaser.Scene {
       if (!this.scene?.isActive()) return;
       this.cameras.main.stopFollow();
       if (rocket) {
-        this.cameras.main.pan(rocket.x, rocket.y, 500, 'Quad.InOut');
+        this.tweens.add({
+          targets: this.cameras.main,
+          scrollX: rocket.x - this.cameras.main.width / 2,
+          scrollY: rocket.y - this.cameras.main.height / 2,
+          duration: 500,
+          ease: 'Quad.InOut',
+        });
       }
     });
 
     // ── Step 5 — Zoom out + rocket ascent (t=700ms) ──────────────────────────
     this.time.delayedCall(700, () => {
       if (!this.scene?.isActive()) return;
-      this.cameras.main.zoomTo(0.6, 1800, 'Quad.Out');
+      this.tweens.add({
+        targets: this.cameras.main,
+        zoom: 0.6,
+        duration: 1800,
+        ease: 'Quad.Out',
+      });
 
       if (rocket) {
         this.tweens.add({


### PR DESCRIPTION
## Summary

- `camera.pan()` and `camera.zoomTo()` throw `Cannot read properties of undefined` on the easing parameter in the current Phaser build
- The fix (replacing both with `tweens.add()`) was applied in commit `19c5a6b` but lost when `05fdd61` resolved audio merge conflicts by taking main's `game.js`
- This PR restores the tween-based approach and adds a secondary guard against double-pressing E during the cinematic

## Changes

### `src/scenes/game.js`
- **Step 4** (`t=350ms`): replace `camera.pan()` with a `scrollX`/`scrollY` tween (500ms, Quad.InOut)
- **Step 5** (`t=700ms`): replace `camera.zoomTo()` with a `zoom` tween (1800ms, Quad.Out)

### `src/gameobjects/rocket.js`
- `interact()`: check `!this.scene._launching` before calling `finishScene()` — prevents duplicate cinematic if player mashes E at the launch prompt

## Root Cause

The regression was introduced by merge commit `05fdd61` ("resolve conflicts, use main branch versions with all audio fixes") which overwrote `game.js` with a version predating the two launch fix commits (`688f389`, `19c5a6b`).

## Test Results
- ✅ Build: clean
- ✅ Tests: 391/391 pass

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)