### PR TITLE
fix(scale): canvas cropped at 1920×1080 — pre-size game-container before Phaser init (#82)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -276,6 +276,10 @@ Bugs are tracked here alongside their GitHub issue. When a bug is reported:
 
 ### Game Bugs
 
+- ✅ **Game canvas cropped at 1920×1080 — player cannot see full play area** [#82](https://github.com/m3ssana/swampfire/issues/82)
+  - Root cause: `#game-container` had zero dimensions at startup; Phaser's Scale Manager fell back to `window.innerWidth/innerHeight` (1920×1080), producing a canvas wider than `.cabinet-screen`; `.crt-frame`'s `overflow:hidden` clipped it
+  - Fix: `sizeGameContainer()` in `main.js` measures `.cabinet-screen` bounds before `new Phaser.Game()` and writes explicit `width`/`height` inline styles on `#game-container`; `window.resize` listener keeps it in sync; `#arcade-cabinet` changed from `min-height` to `height: 100vh` so the `1fr` row has a computable pixel height
+
 - ✅ **White smoke particle trail follows Juan in Zone 0** [#72](https://github.com/m3ssana/swampfire/issues/72)
   - Removed Dust particle class and all references (step trail + death explosion) from player
 

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -44,7 +44,7 @@ html, body {
     "header  header  header"
     "left    screen  right"
     "footer  footer  footer";
-  min-height: 100vh;
+  height: 100vh;   /* fixed height so 1fr row has a computable pixel size */
   background: #0a0a0a;
 }
 
@@ -140,6 +140,7 @@ html, body {
   justify-content: center;
   padding: 12px;
   background: #0a0a0a;
+  min-height: 0;   /* allow grid row to shrink; prevents overflow when height: 100vh is set */
 }
 
 .crt-frame {

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,30 @@ import Game from "./scenes/game";
 import HUD from "./scenes/hud";
 import PhaserMatterCollisionPlugin from "phaser-matter-collision-plugin";
 
+// Pre-size #game-container before Phaser init.
+// Without this, #game-container has zero dimensions at startup, causing Phaser's
+// Scale Manager to fall back to window.innerWidth/innerHeight.  At 1920×1080 that
+// produces a canvas larger than the .cabinet-screen column, which is then clipped
+// by .crt-frame's overflow:hidden.  We measure the available area inside
+// .cabinet-screen and set an explicit size so Phaser reads the correct bounds.
+const GAME_W = 1280;
+const GAME_H = 720;
+
+function sizeGameContainer() {
+  const screen = document.querySelector(".cabinet-screen");
+  const container = document.getElementById("game-container");
+  if (!screen || !container) return;
+  const { width, height } = screen.getBoundingClientRect();
+  const pad = 12; // matches padding: 12px on .cabinet-screen
+  const availW = width - pad * 2;
+  const availH = height - pad * 2;
+  const scale = Math.min(availW / GAME_W, availH / GAME_H);
+  container.style.width = `${Math.floor(GAME_W * scale)}px`;
+  container.style.height = `${Math.floor(GAME_H * scale)}px`;
+}
+
+sizeGameContainer();
+
 const config = {
   width: 1280,
   height: 720,
@@ -36,6 +60,14 @@ const config = {
 };
 
 const game = new Phaser.Game(config);
+
+// Keep the canvas correctly sized on window resize.
+// Phaser re-reads #game-container's dimensions on each scale refresh, so we
+// must update the inline styles before calling refresh().
+window.addEventListener("resize", () => {
+  sizeGameContainer();
+  game.scale.refresh();
+});
 
 // Expose game instance for E2E tests to access state directly
 // Tests can access: window.game.scene.scenes[3].registry.get('hp'), etc.


### PR DESCRIPTION
## Summary

- `#game-container` had zero dimensions at startup, causing Phaser's Scale Manager to fall back to `window.innerWidth/innerHeight` and create a 1920×1080 canvas — wider than the `.cabinet-screen` column — which `.crt-frame`'s `overflow: hidden` then clipped
- Added `sizeGameContainer()` in `main.js` that measures `.cabinet-screen` bounds _before_ `new Phaser.Game()` and writes explicit `width`/`height` on `#game-container` so `Scale.FIT` reads the correct container size
- Added `window.resize` listener to re-run sizing and call `game.scale.refresh()` on viewport changes
- Changed `#arcade-cabinet` from `min-height: 100vh` → `height: 100vh` so the `1fr` grid row has a definite pixel height at startup
- Added `min-height: 0` to `.cabinet-screen` to prevent flex/grid overflow

Closes #82

## Test plan

- [ ] Open game at 1920×1080 viewport — full 1280×720 canvas visible, no clipping on right or bottom edge
- [ ] Open game at 1280×800 — canvas scales down correctly, still centered in cabinet
- [ ] Resize browser window — canvas re-scales without cropping
- [ ] Check all four breakpoints (`@media` at 1400px, 1100px, 700px) — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)