### PR TITLE
fix(hud): guard BitmapText updaters against null chars crash on second run (#86)

### DIFF
--- a/src/scenes/hud.js
+++ b/src/scenes/hud.js
@@ -153,6 +153,10 @@ export default class HUD extends Phaser.Scene {
   // ─── Registry listener ──────────────────────────────────────────────────────
 
   onRegistryChange(parent, key, value) {
+    // Guard against stale listeners firing after scene.stop() destroys game objects.
+    // sys.isActive() is false once the scene has been stopped or shut down.
+    if (!this.sys.isActive()) return;
+
     switch (key) {
       case "timeLeft":        this.updateTimerDisplay(value); break;
       case "hp":              this.updateHearts(value);       break;
@@ -167,6 +171,7 @@ export default class HUD extends Phaser.Scene {
   // ─── Display updaters ───────────────────────────────────────────────────────
 
   updateTimerDisplay(seconds) {
+    if (!this.timerText?.active) return;
     const m = Math.floor(seconds / 60).toString().padStart(2, "0");
     const s = (seconds % 60).toString().padStart(2, "0");
     this.timerText.setText(`${m}:${s}`);
@@ -187,6 +192,7 @@ export default class HUD extends Phaser.Scene {
   }
 
   updatePhase(phase) {
+    if (!this.timerText?.active) return;
     const PHASE_TINTS = { 1: 0x4fffaa, 2: 0xffee44, 3: 0xff8800, 4: 0xff2222 };
     const tint = PHASE_TINTS[phase] ?? 0x4fffaa;
 
@@ -278,12 +284,14 @@ export default class HUD extends Phaser.Scene {
   }
 
   updateHearts(hp) {
+    if (!this.hearts?.length) return;
     this.hearts.forEach((heart, i) => {
       heart.setFillStyle(i < hp ? 0xdd2222 : 0x2a2a2a);
     });
   }
 
   updateXP(xp) {
+    if (!this.xpText?.active) return;
     this.xpText.setText(String(xp));
   }
 


### PR DESCRIPTION
## Summary

After `scene.stop("hud")` destroys BitmapText objects, a stale registry `changedata` listener (or a registry change that fires before the new HUD's `create()` completes on the second launch) calls `updateXP` → `xpText.setText()` on a destroyed object whose font `chars` data is null — crashing the game.

**Two-layer fix in `src/scenes/hud.js`:**

- **`onRegistryChange`** — early return if `this.sys.isActive()` is false. This is the primary fix: catches any stale listener firing after `scene.stop()` has shut the scene down.
- **`updateTimerDisplay`, `updatePhase`, `updateXP`, `updateHearts`** — `?.active` / `?.length` guards on each BitmapText/object before calling `setText`/`setTint`/`setFillStyle`. Belt-and-suspenders against the startup race where a registry event fires before `create()` has finished rebuilding objects on the second launch.

Closes #86

## Test plan

- [ ] Complete a full run (win or lose) and click Restart on the Outro screen
- [ ] Play through the second run — award XP by looting, crafting, or installing — no crash
- [ ] Verify HUD timer, XP counter, hearts, and systems counter all update normally on the second run
- [ ] Complete a second run and restart again (third run) — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)