### PR TITLE
fix(hazards): move power line spawns onto US-41 road tiles (#88)

### DIFF
--- a/src/gameobjects/hazard_manager.js
+++ b/src/gameobjects/hazard_manager.js
@@ -74,11 +74,14 @@ const LOOTER_PATROLS = [
 ];
 
 // Power line drop positions in Zone 1 — live end coordinates.
-// Placed at road intersections and store fronts for maximum navigational impact.
+// All three points are on US-41 asphalt (ground layer GID 1, tile col 38,
+// which sits in the road band cols 33-44). Previous spawns used cols 22, 48,
+// and 62 — col 22 landed on store-floor tiles (GID 5, Harvey's Hardware
+// interior), causing the pole to render inside the building.
 const POWERLINE_SPAWNS = [
-  { x: 22 * 48, y: 28 * 48 },   // main highway north section
-  { x: 48 * 48, y: 35 * 48 },   // mid-corridor intersection
-  { x: 62 * 48, y: 22 * 48 },   // east parking lot
+  { x: 38 * 48, y: 15 * 48 },   // US-41 north section
+  { x: 38 * 48, y: 30 * 48 },   // US-41 centre
+  { x: 38 * 48, y: 45 * 48 },   // US-41 south section
 ];
 
 // Flood zones in Zone 1 — AABB rectangles (top-left x/y, width, height).


### PR DESCRIPTION
## Summary

Power line at tile (22, 28) was spawning on **ground GID 5** (Harvey's Hardware store floor — a passable but visually indoor tile). The obstacle layer shows 0 (no wall tile) there, which is why automated checks missed it — building interiors are walkable but are clearly indoors.

Screenshot from issue #88 confirmed the pole rendering inside the building.

**Root cause:** `POWERLINE_SPAWNS` coordinates were chosen against the obstacle layer (walls only), not the ground layer. GID 5 (store floor) is passable but indoors; the road is GID 1 (asphalt, cols 33–44).

**Fix:** All three spawns moved to tile column 38 (mid-road on US-41, GID 1 asphalt), spaced north/centre/south across the zone:

| Before | Tile | Ground GID | Location |
|--------|------|------------|----------|
| Spawn 1 | (22, 28) | 5 | ❌ Harvey's Hardware interior |
| Spawn 2 | (48, 35) | 2 | Parking lot (ok but off-road) |
| Spawn 3 | (62, 22) | 2 | Parking lot (ok but off-road) |

| After | Tile | Ground GID | Location |
|-------|------|------------|----------|
| Spawn 1 | (38, 15) | 1 | ✅ US-41 road, north |
| Spawn 2 | (38, 30) | 1 | ✅ US-41 road, centre |
| Spawn 3 | (38, 45) | 1 | ✅ US-41 road, south |

Closes #88

## Test plan

- [ ] Reach storm Phase 3 in Zone 1 — all three power lines appear on the highway, not inside any building
- [ ] Power line arc-flash sparks and warn radius are fully visible on road tiles
- [ ] Player can approach and trigger near-miss warning from the road
- [ ] No power line pole overlaps a building wall or store interior

🤖 Generated with [Claude Code](https://claude.com/claude-code)