### PR TITLE
feat: fix XP values per SPEC (#112)

### DIFF
--- a/src/gameobjects/looter.js
+++ b/src/gameobjects/looter.js
@@ -225,6 +225,9 @@ export default class Looter {
     const { x, y } = this._body.position;
     this.scene.showPoints(x, y - 28, '! looter !', 0xff4444);
     this.scene.cameras.main.flash(50, 0xff, 0x44, 0x44, true);
+    const xp = this.scene.registry.get('xp') ?? 0;
+    this.scene.registry.set('xp', xp + 15);
+    this.scene.showXPGain(x, y - 52, 15, 'nearmiss');
 
     this.scene.time.delayedCall(2000, () => { this._nearPlayer = false; });
   }

--- a/src/gameobjects/npc.js
+++ b/src/gameobjects/npc.js
@@ -8,7 +8,7 @@ const NPC_CONFIGS = {
     doneDialog: 'You\'re a legend. Go launch that thing!',
     quest: {
       wantLabel: 'Copper Wiring',
-      reward: { xp: 30, item: { label: 'Solenoid Valve', type: 'ingredient', tint: 0x88aaff } }
+      reward: { xp: 200, item: { label: 'Solenoid Valve', type: 'ingredient', tint: 0x88aaff } }
     }
   },
   maria: {
@@ -18,7 +18,7 @@ const NPC_CONFIGS = {
     doneDialog: 'Side entrance is faster — good luck out there!',
     quest: {
       wantLabel: 'Multi-tool',
-      reward: { xp: 30, item: { label: 'Steel Bracket', type: 'ingredient', tint: 0xaaaaaa } }
+      reward: { xp: 200, item: { label: 'Steel Bracket', type: 'ingredient', tint: 0xaaaaaa } }
     }
   },
   dale: {
@@ -28,7 +28,7 @@ const NPC_CONFIGS = {
     doneDialog: 'Storm eye passes soon. You got this, son.',
     quest: {
       wantLabel: 'Road Flare',
-      reward: { xp: 40 }
+      reward: { xp: 200 }
     }
   },
   reeves: {
@@ -38,7 +38,7 @@ const NPC_CONFIGS = {
     doneDialog: 'Lab\'s open! Pressure Gauge inside — go go go!',
     quest: {
       wantLabel: 'Hydraulic Seal',
-      reward: { xp: 35, item: { label: 'Pressure Gauge', type: 'ingredient', tint: 0xffaa44 } }
+      reward: { xp: 200, item: { label: 'Pressure Gauge', type: 'ingredient', tint: 0xffaa44 } }
     }
   }
 };
@@ -127,7 +127,7 @@ export default class NPC {
       this.scene.showXPGain(
         this.sprite.x, this.sprite.y - 40,
         this._config.quest.reward.xp,
-        'loot'
+        'quest'
       );
 
       // Add reward item if present

--- a/src/gameobjects/power_line.js
+++ b/src/gameobjects/power_line.js
@@ -242,6 +242,9 @@ export default class PowerLine {
 
     this.scene.showPoints(this._x, this._y - 32, '! live wire !', 0xffee00);
     this.scene.cameras.main.flash(80, 0xff, 0xee, 0x00, true);
+    const xp = this.scene.registry.get('xp') ?? 0;
+    this.scene.registry.set('xp', xp + 15);
+    this.scene.showXPGain(this._x, this._y - 56, 15, 'nearmiss');
 
     this.scene.time.delayedCall(2000, () => { this._nearPlayer = false; });
   }

--- a/src/gameobjects/rattlesnake.js
+++ b/src/gameobjects/rattlesnake.js
@@ -220,6 +220,9 @@ export default class Rattlesnake {
     const { x, y } = this.sprite;
     this.scene.showPoints(x, y - 24, '~ rattle ~', 0xaaff44);
     this.scene.cameras.main.flash(60, 0xaa, 0xff, 0x44);
+    const xp = this.scene.registry.get('xp') ?? 0;
+    this.scene.registry.set('xp', xp + 15);
+    this.scene.showXPGain(x, y - 48, 15, 'nearmiss');
 
     // Reset debounce after the player has had time to move away
     this.scene.time.delayedCall(1500, () => { this._nearPlayer = false; });

--- a/src/gameobjects/rocket.js
+++ b/src/gameobjects/rocket.js
@@ -81,15 +81,29 @@ export default class Rocket {
 
     // Award XP
     const xp = this.scene.registry.get('xp') ?? 0;
-    this.scene.registry.set('xp', xp + 20);
+    this.scene.registry.set('xp', xp + 500);
 
-    // Feedback — label popup + separate XP popup
+    // Feedback — label popup + XP popup + red flash + zoom bump + shake
     this.scene.showPoints(
       this.sprite.x, this.sprite.y - 40,
       `${component.label} installed`, component.tint ?? 0x4fffaa
     );
-    this.scene.showXPGain(this.sprite.x, this.sprite.y - 40, 20, 'install');
+    this.scene.showXPGain(this.sprite.x, this.sprite.y - 40, 500, 'install');
+    this.scene.cameras.main.flash(200, 0xff, 0x44, 0x22);
     this.scene.cameras.main.shake(180, 0.008);
+    // Brief zoom-in to 2.0x then pull back to 1.5x
+    this.scene.tweens.add({
+      targets: this.scene.cameras.main,
+      zoom: 2.0,
+      duration: 150,
+      ease: 'Quad.Out',
+      onComplete: () => this.scene.tweens.add({
+        targets: this.scene.cameras.main,
+        zoom: 1.5,
+        duration: 400,
+        ease: 'Quad.InOut',
+      }),
+    });
     this.scene.playAudio('install');
   }
 

--- a/src/gameobjects/rocket.js
+++ b/src/gameobjects/rocket.js
@@ -92,13 +92,15 @@ export default class Rocket {
     this.scene.cameras.main.flash(200, 0xff, 0x44, 0x22);
     this.scene.cameras.main.shake(180, 0.008);
     // Brief zoom-in to 2.0x then pull back to 1.5x
+    const cam = this.scene.cameras.main;
+    this.scene.tweens.killTweensOf(cam);
     this.scene.tweens.add({
-      targets: this.scene.cameras.main,
+      targets: cam,
       zoom: 2.0,
       duration: 150,
       ease: 'Quad.Out',
       onComplete: () => this.scene.tweens.add({
-        targets: this.scene.cameras.main,
+        targets: cam,
         zoom: 1.5,
         duration: 400,
         ease: 'Quad.InOut',

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -7,9 +7,12 @@ import AchievementManager             from "../gameobjects/achievement_manager";
 
 // ── XP Popup tuning ───────────────────────────────────────────────────────────
 const XP_COLORS = {
-  loot:    0x44ff88,  // green  — item found in container
-  craft:   0xffdd00,  // gold   — rocket component crafted
-  install: 0x00eeff,  // cyan   — component installed on rocket
+  loot:    0x44ff88,  // green      — item found in container
+  craft:   0xffdd00,  // gold       — rocket component crafted
+  install: 0xff4422,  // red        — component installed on rocket (big payoff)
+  quest:   0xcc44ff,  // purple     — NPC quest completed
+  nearmiss:0xaaff44,  // lime green — hazard dodged
+  discover:0x00eeff,  // cyan       — new zone entered for the first time
 };
 /** ms window in which rapid same-context XP grants merge into one popup */
 const XP_MERGE_MS = 400;
@@ -287,6 +290,19 @@ export default class Game extends Phaser.Scene {
 
     this.showPoints(itemSprite.x, itemSprite.y, `+ ${itemDef.label}`, itemDef.tint);
     this.playAudio('loot');
+
+    // Zoom bump when a rocket component lands in inventory (type: 'component')
+    if (itemDef.type === 'component') {
+      const cam = this.cameras.main;
+      this.tweens.add({
+        targets: cam,
+        zoom: 1.6,
+        duration: 100,
+        ease: 'Quad.Out',
+        onComplete: () => this.tweens.add({ targets: cam, zoom: 1.5, duration: 200, ease: 'Quad.InOut' }),
+      });
+    }
+
     itemSprite.destroy();
   }
 
@@ -572,6 +588,7 @@ export default class Game extends Phaser.Scene {
       // ── Swap zones ──────────────────────────────────────────────────────────
       this.zone.destroyCurrentZone();
       this.zone.loadZone(targetZoneId, sourceZoneId);
+      const isNewZone = !this._visitedZones.has(targetZoneId);
       this._visitedZones.add(targetZoneId);
       this.registry.set('visitedZones', [...this._visitedZones]);
 
@@ -587,6 +604,15 @@ export default class Game extends Phaser.Scene {
 
       // ── Notify hazard manager of new zone ────────────────────────────────────
       this.events.emit('zoneChanged', targetZoneId);
+
+      // ── Zone discovery XP (first visit only) ────────────────────────────────
+      if (isNewZone) {
+        this.time.delayedCall(350, () => {
+          const xp = this.registry.get('xp') ?? 0;
+          this.registry.set('xp', xp + 50);
+          this.showXPGain(entry.x, entry.y - 60, 50, 'discover');
+        });
+      }
 
       // ── Fade back in ────────────────────────────────────────────────────────
       this.cameras.main.fadeIn(250, 0, 0, 0);

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -294,6 +294,7 @@ export default class Game extends Phaser.Scene {
     // Zoom bump when a rocket component lands in inventory (type: 'component')
     if (itemDef.type === 'component') {
       const cam = this.cameras.main;
+      this.tweens.killTweensOf(this.cameras.main);
       this.tweens.add({
         targets: cam,
         zoom: 1.6,
@@ -353,7 +354,7 @@ export default class Game extends Phaser.Scene {
     @param {number} x       - World X of the event source
     @param {number} y       - World Y of the event source
     @param {number} amount  - XP amount gained (ignored if ≤ 0)
-    @param {string} context - 'loot' | 'craft' | 'install'
+    @param {string} context - 'loot' | 'craft' | 'install' | 'quest' | 'nearmiss' | 'discover'
   */
   showXPGain(x, y, amount, context = 'loot') {
     if (amount <= 0) return;


### PR DESCRIPTION
## Summary
Fixes all XP award values to match the §4.3.1 SPEC table. The previous values were 10–25× too low, undermining the dopamine feedback loop on the most important actions.

## Changes
| Action | Before | After | Color |
|--------|--------|-------|-------|
| System install | +20 | +500 | 🔴 Red |
| NPC quest | +30–40 | +200 | 🟣 Purple |
| Near-miss dodge | +0 | +15 | 🟢 Lime green |
| New zone discover | +0 | +50 | 🩵 Cyan |
| Rocket component pickup | zoom: none | zoom bump 1.5→1.6× | — |

Also adds a red camera flash + zoom-to-2× on install to match the "massive payoff" feel the SPEC describes.

## Files changed
- `src/scenes/game.js` — XP_COLORS table, component zoom bump, zone-discover XP
- `src/gameobjects/rocket.js` — install XP + flash + zoom
- `src/gameobjects/npc.js` — quest XP values + 'quest' context
- `src/gameobjects/rattlesnake.js` / `looter.js` / `power_line.js` — near-miss +15 XP

## Test plan
- [x] 391/391 unit tests passing
- [ ] Manually verify install triggers red +500 popup + flash + zoom
- [ ] Manually verify NPC quest triggers purple +200 popup
- [ ] Manually verify rattlesnake/looter/powerline near-miss shows lime +15 popup
- [ ] Manually verify entering a new zone shows cyan +50 popup (only once per zone)
- [ ] Verify revisiting a zone does NOT re-award the +50

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)