### PR TITLE
feat(9.0.3): add 5th rocket system — Pressure Regulator

### DIFF
--- a/src/gameobjects/achievement_manager.js
+++ b/src/gameobjects/achievement_manager.js
@@ -60,9 +60,9 @@ export const ACHIEVEMENTS = [
   {
     id:    'all_systems',
     label: '★ LAUNCH READY',
-    // all 4 rocket systems installed — rocket is ready to fire
+    // all 5 rocket systems installed — rocket is ready to fire
     watch: 'systemsInstalled',
-    check: (value) => value >= 4,
+    check: (value) => value >= 5,
   },
   {
     id:    'explorer',

--- a/src/gameobjects/achievement_manager.js
+++ b/src/gameobjects/achievement_manager.js
@@ -18,7 +18,7 @@
  *   first_loot    — picked up any item from a container
  *   first_craft   — crafted the first rocket component
  *   first_install — installed the first rocket system
- *   all_systems   — all 4 systems installed (launch ready)
+ *   all_systems   — all 5 systems installed (launch ready)
  *   explorer      — left the starting zone for the first time
  *   globe_trotter — visited all 5 zones (0–4)
  *   first_frenzy  — triggered FRENZY combo for the first time

--- a/src/gameobjects/rocket.js
+++ b/src/gameobjects/rocket.js
@@ -1,18 +1,19 @@
 /**
  * Rocket — E-key installable that accepts crafted components and launches when full.
  *
- * 5 visual states (0–4 systems installed), implemented via tint on a single sprite:
+ * 6 visual states (0–5 systems installed), implemented via tint on a single sprite:
  *   0  Grey    — untouched
  *   1  Warm    — first system in
- *   2  Warmer  — halfway there
- *   3  Almost  — one away
- *   4  Gold    — all systems go; pressing E triggers finishScene()
+ *   2  Warmer  — two in
+ *   3  Almost  — halfway there
+ *   4  Hot     — one away
+ *   5  Gold    — all systems go; pressing E triggers finishScene()
  *
- * Prompt text flips from "[E] Install" to "[E] Launch" after the 4th system.
+ * Prompt text flips from "[E] Install" to "[E] Launch" after the 5th system.
  * This is re-evaluated on every proximity entry so the text is always fresh.
  */
 
-const TINTS = [0x666666, 0x998877, 0xaabb99, 0xbbddcc, 0xffee44];
+const TINTS = [0x666666, 0x998877, 0xaabb99, 0xbbddcc, 0xff44aa, 0xffee44];
 
 export default class Rocket {
   /**
@@ -33,13 +34,13 @@ export default class Rocket {
 
   promptText() {
     const n = this.scene.registry.get('systemsInstalled') ?? 0;
-    return n >= 4 ? '[E] Launch' : '[E] Install';
+    return n >= 5 ? '[E] Launch' : '[E] Install';
   }
 
   /**
    * Called when player presses E while this rocket is nearby.
    *
-   * - If all 4 systems installed → triggers the win condition.
+   * - If all 5 systems installed → triggers the win condition.
    * - If a crafted component exists → installs it, increments counter, updates visual.
    * - Otherwise → shows error prompt.
    */
@@ -48,7 +49,7 @@ export default class Rocket {
     const inv = this.scene.registry.get('inventory') ?? [];
 
     // All systems installed — launch! Guard against double-press during cinematic.
-    if (n >= 4) {
+    if (n >= 5) {
       if (!this.scene._launching) this.scene.finishScene();
       return;
     }
@@ -117,7 +118,7 @@ export default class Rocket {
    */
   updateVisual() {
     const n = this.scene.registry.get('systemsInstalled') ?? 0;
-    this.sprite.setTint(TINTS[Math.min(n, 4)]);
+    this.sprite.setTint(TINTS[Math.min(n, 5)]);
   }
 
   // ── Cleanup ──────────────────────────────────────────────────────────────────

--- a/src/gameobjects/searchable_container.js
+++ b/src/gameobjects/searchable_container.js
@@ -24,7 +24,7 @@ const LOOT_TABLES = {
     { label: "Copper Wiring",  xp:  5, tint: 0x4fc3f7, weight: 25, type: "ingredient" },
     { label: "Solenoid Valve", xp: 10, tint: 0x4fc3f7, weight: 20, type: "ingredient" },
     { label: "Hydraulic Seal", xp:  5, tint: 0x4fc3f7, weight: 20, type: "ingredient" },
-    { label: "PVC Coupler",    xp:  3, tint: 0xffffff, weight: 20, type: "junk" },
+    { label: "PVC Coupler",    xp:  3, tint: 0xffffff, weight: 20, type: "ingredient" },
     { label: "Empty",          xp:  0, tint: 0x666666, weight: 15, type: "junk" },
   ],
 

--- a/src/gameobjects/searchable_container.js
+++ b/src/gameobjects/searchable_container.js
@@ -50,7 +50,7 @@ const LOOT_TABLES = {
     { label: "Water Bottle",     xp:  2, tint: 0x40c4ff, weight: 25, type: "junk" },
     { label: "Beef Jerky",       xp:  3, tint: 0xa1887f, weight: 20, type: "junk" },
     { label: "Hydraulic Seal",   xp:  5, tint: 0x4fc3f7, weight: 15, type: "ingredient" },
-    { label: "PVC Coupler",      xp:  3, tint: 0xffffff, weight:  8, type: "junk" },
+    { label: "PVC Coupler",      xp:  3, tint: 0xffffff, weight:  8, type: "ingredient" },
     { label: "Empty",            xp:  0, tint: 0x666666, weight:  2, type: "junk" },
   ],
 

--- a/src/gameobjects/workbench.js
+++ b/src/gameobjects/workbench.js
@@ -8,14 +8,15 @@
  *
  * Guards:
  *   - Requires exactly ≥2 ingredients; shows error if fewer
- *   - No-ops if all 4 systems are already built (installed + crafted ≥ 4)
+ *   - No-ops if all 5 systems are already built (installed + crafted ≥ 5)
  */
 
 const ROCKET_SYSTEMS = [
-  { label: 'Fuel Injector',  xp: 15, tint: 0xff6600 },
-  { label: 'Oxidizer Tank',  xp: 15, tint: 0x00ccff },
-  { label: 'Avionics Board', xp: 15, tint: 0x00ff88 },
-  { label: 'Battery Array',  xp: 15, tint: 0xffee00 },
+  { label: 'Fuel Injector',       xp: 15, tint: 0xff6600 },
+  { label: 'Oxidizer Tank',       xp: 15, tint: 0x00ccff },
+  { label: 'Avionics Board',      xp: 15, tint: 0x00ff88 },
+  { label: 'Battery Array',       xp: 15, tint: 0xffee00 },
+  { label: 'Pressure Regulator',  xp: 15, tint: 0xff44aa },
 ];
 
 export default class Workbench {
@@ -45,8 +46,8 @@ export default class Workbench {
     const crafted    = inv.filter(i => i.type === 'component').length;
     const totalBuilt = installed + crafted;
 
-    // All 4 systems already accounted for — nothing left to build
-    if (totalBuilt >= 4) {
+    // All 5 systems already accounted for — nothing left to build
+    if (totalBuilt >= 5) {
       this.scene.showPoints(this.sprite.x, this.sprite.y - 20, 'All systems built!', 0x888888);
       return;
     }

--- a/src/scenes/hud.js
+++ b/src/scenes/hud.js
@@ -128,7 +128,7 @@ export default class HUD extends Phaser.Scene {
 
     // Live systems counter — updated via updateSystems()
     this.systemsText = this.add
-      .bitmapText(mx, my - 8, 'default', '0 / 4', 26)
+      .bitmapText(mx, my - 8, 'default', '0 / 5', 26)
       .setOrigin(0.5).setTint(0xffee44);
 
     // Footer label
@@ -296,8 +296,8 @@ export default class HUD extends Phaser.Scene {
   }
 
   updateSystems(n) {
-    this.systemsText?.setText(`${n} / 4`);
-    this.systemsText?.setTint(n >= 4 ? 0x4fffaa : 0xffee44);
+    this.systemsText?.setText(`${n} / 5`);
+    this.systemsText?.setTint(n >= 5 ? 0x4fffaa : 0xffee44);
   }
 
   // ─── Cleanup ────────────────────────────────────────────────────────────────

--- a/src/scenes/outro.js
+++ b/src/scenes/outro.js
@@ -4,7 +4,7 @@
  * Handles all three end states:
  *   "death"   — HP hit 0. Florida Man headline + stats.
  *   "timeout" — Timer hit 0:00. Hurricane made landfall.
- *   "victory" — All 4 systems installed. Placeholder for Phase 6.
+ *   "victory" — All 5 systems installed. Placeholder for Phase 6.
  *
  * Stats are read from Phaser's global registry (set by HUDScene / GameScene).
  * SPACE or ENTER returns to the splash screen.
@@ -115,11 +115,11 @@ export default class Outro extends Phaser.Scene {
       .setTint(0xdddddd)
       .setCenterAlign();
 
-    // Rocket progress — 0/4 until Phase 2 wires up system tracking
+    // Rocket progress — 0/5 until Phase 2 wires up system tracking
     const systems = this.registry.get("systemsInstalled") ?? 0;
     this.add
       .bitmapText(this.cx, 148, "default",
-        `Juan's rocket sat ${systems}/4 systems complete\nin Cypress Creek Preserve.`, 15)
+        `Juan's rocket sat ${systems}/5 systems complete\nin Cypress Creek Preserve.`, 15)
       .setOrigin(0.5, 0)
       .setTint(0x4fffaa)
       .setCenterAlign();
@@ -169,7 +169,7 @@ export default class Outro extends Phaser.Scene {
     // SYSTEMS INSTALLED — victory screen only
     const systems = this.registry.get("systemsInstalled") ?? 0;
     this.add
-      .bitmapText(this.cx, statsY + 55, "default", `SYSTEMS INSTALLED: ${systems} / 4`, 18)
+      .bitmapText(this.cx, statsY + 55, "default", `SYSTEMS INSTALLED: ${systems} / 5`, 18)
       .setOrigin(0.5)
       .setTint(0x00eeff);
   }

--- a/tests/achievement-manager.test.js
+++ b/tests/achievement-manager.test.js
@@ -134,12 +134,12 @@ describe('Achievement check() functions', () => {
     it('1 → true',  () => { expect(a.check(1)).toBe(true);  });
   });
 
-  describe('all_systems — systemsInstalled >= 4', () => {
+  describe('all_systems — systemsInstalled >= 5', () => {
     const a = ACHIEVEMENTS.find(x => x.id === 'all_systems');
 
-    it('3 → false', () => { expect(a.check(3)).toBe(false); });
-    it('4 → true',  () => { expect(a.check(4)).toBe(true);  });
-    it('5 → true (defensive against overshoot)', () => { expect(a.check(5)).toBe(true); });
+    it('4 → false', () => { expect(a.check(4)).toBe(false); });
+    it('5 → true',  () => { expect(a.check(5)).toBe(true);  });
+    it('6 → true (defensive against overshoot)', () => { expect(a.check(6)).toBe(true); });
   });
 
   describe('explorer — visitedZones.length >= 2', () => {
@@ -227,21 +227,21 @@ describe('AchievementManager — unlock via registry change', () => {
     expect(mgr.isUnlocked('first_install')).toBe(true);
   });
 
-  it('all_systems unlocks when systemsInstalled reaches 4', () => {
+  it('all_systems unlocks when systemsInstalled reaches 5', () => {
     const scene = makeScene({ systemsInstalled: 0 });
     const mgr = makeManager(scene);
 
-    scene.registry.set('systemsInstalled', 4);
+    scene.registry.set('systemsInstalled', 5);
 
     expect(mgr.isUnlocked('all_systems')).toBe(true);
     expect(mgr.toasts).toContain('★ LAUNCH READY');
   });
 
-  it('explorer and all_systems unlock in same change when jumping 0→4', () => {
+  it('explorer and all_systems unlock in same change when jumping 0→5', () => {
     const scene = makeScene({ systemsInstalled: 0 });
     const mgr = makeManager(scene);
 
-    scene.registry.set('systemsInstalled', 4);
+    scene.registry.set('systemsInstalled', 5);
 
     // Both first_install AND all_systems should unlock from same change
     expect(mgr.isUnlocked('first_install')).toBe(true);

--- a/tests/game-logic.test.js
+++ b/tests/game-logic.test.js
@@ -4,7 +4,7 @@
  * Unit tests for core game systems that don't require the full Phaser runtime:
  * - Inventory management (add/remove items, persistence)
  * - Crafting recipes (ingredient consumption, component creation)
- * - Rocket installation (4-system sequence, win condition)
+ * - Rocket installation (5-system sequence, win condition)
  * - State transitions (hp loss, xp gain, timer decrement)
  * - Loot table validation (weighted random selection)
  */

--- a/tests/game-logic.test.js
+++ b/tests/game-logic.test.js
@@ -15,10 +15,11 @@ import { getPhaseForTimeLeft } from '../src/gameobjects/storm_phase_logic.js';
 // ── Crafting system ─────────────────────────────────────────────────────────
 
 const ROCKET_SYSTEMS = [
-  { label: 'Fuel Injector', xp: 15, tint: 0xff6600 },
-  { label: 'Oxidizer Tank', xp: 15, tint: 0x00ccff },
-  { label: 'Avionics Board', xp: 15, tint: 0x00ff88 },
-  { label: 'Battery Array', xp: 15, tint: 0xffee00 },
+  { label: 'Fuel Injector',      xp: 15, tint: 0xff6600 },
+  { label: 'Oxidizer Tank',      xp: 15, tint: 0x00ccff },
+  { label: 'Avionics Board',     xp: 15, tint: 0x00ff88 },
+  { label: 'Battery Array',      xp: 15, tint: 0xffee00 },
+  { label: 'Pressure Regulator', xp: 15, tint: 0xff44aa },
 ];
 
 describe('Inventory System', () => {
@@ -101,13 +102,13 @@ describe('Crafting System', () => {
     expect(ingredients.length >= 2).toBe(false);
   });
 
-  it('prevents crafting when all 4 systems are built', () => {
+  it('prevents crafting when all 5 systems are built', () => {
     const inventory = [];
-    const installed = 4;
+    const installed = 5;
     const crafted = 0;
     const totalBuilt = installed + crafted;
 
-    expect(totalBuilt >= 4).toBe(true);
+    expect(totalBuilt >= 5).toBe(true);
   });
 
   it('produces the correct component in sequence', () => {
@@ -131,24 +132,25 @@ describe('Crafting System', () => {
     expect(xp).toBe(15);
   });
 
-  it('handles full 4-component crafting sequence', () => {
+  it('handles full 5-component crafting sequence', () => {
     let inventory = [];
     let xp = 0;
 
-    // Craft all 4 components
-    for (let i = 0; i < 4; i++) {
+    // Craft all 5 components
+    for (let i = 0; i < 5; i++) {
       const recipe = ROCKET_SYSTEMS[i];
       inventory.push({ label: recipe.label, type: 'component', tint: recipe.tint });
       xp += recipe.xp;
     }
 
-    expect(inventory).toHaveLength(4);
-    expect(xp).toBe(60); // 15 * 4
+    expect(inventory).toHaveLength(5);
+    expect(xp).toBe(75); // 15 * 5
     expect(inventory.map(c => c.label)).toEqual([
       'Fuel Injector',
       'Oxidizer Tank',
       'Avionics Board',
       'Battery Array',
+      'Pressure Regulator',
     ]);
   });
 });
@@ -182,16 +184,16 @@ describe('Rocket Installation', () => {
     expect(newInv).toHaveLength(1);
   });
 
-  it('triggers win condition at 4 systems installed', () => {
-    let systemsInstalled = 3;
+  it('triggers win condition at 5 systems installed', () => {
+    let systemsInstalled = 4;
     const inventory = [{ type: 'component' }];
 
     if (inventory.some(i => i.type === 'component')) {
       systemsInstalled++;
     }
 
-    expect(systemsInstalled).toBe(4);
-    expect(systemsInstalled >= 4).toBe(true);
+    expect(systemsInstalled).toBe(5);
+    expect(systemsInstalled >= 5).toBe(true);
   });
 
   it('completes the full installation sequence', () => {
@@ -201,10 +203,11 @@ describe('Rocket Installation', () => {
       { type: 'component' },
       { type: 'component' },
       { type: 'component' },
+      { type: 'component' },
     ];
 
-    // Install all 4 components
-    while (inventory.length > 0 && systemsInstalled < 4) {
+    // Install all 5 components
+    while (inventory.length > 0 && systemsInstalled < 5) {
       let installed = false;
       inventory = inventory.filter(item => {
         if (!installed && item.type === 'component') {
@@ -216,7 +219,7 @@ describe('Rocket Installation', () => {
       });
     }
 
-    expect(systemsInstalled).toBe(4);
+    expect(systemsInstalled).toBe(5);
     expect(inventory).toHaveLength(0);
   });
 });
@@ -276,7 +279,7 @@ describe('Loot Table System', () => {
       { label: 'Copper Wiring', xp: 5, tint: 0x4fc3f7, weight: 25, type: 'ingredient' },
       { label: 'Solenoid Valve', xp: 10, tint: 0x4fc3f7, weight: 20, type: 'ingredient' },
       { label: 'Hydraulic Seal', xp: 5, tint: 0x4fc3f7, weight: 20, type: 'ingredient' },
-      { label: 'PVC Coupler', xp: 3, tint: 0xffffff, weight: 20, type: 'junk' },
+      { label: 'PVC Coupler', xp: 3, tint: 0xffffff, weight: 20, type: 'ingredient' },
       { label: 'Empty', xp: 0, tint: 0x666666, weight: 15, type: 'junk' },
     ],
   };
@@ -364,8 +367,8 @@ describe('Core Gameplay Loop', () => {
       inventory.push({ label: 'Ingredient', type: 'ingredient' });
     }
 
-    // Craft components (repeat 4 times)
-    for (let craft = 0; craft < 4; craft++) {
+    // Craft components (repeat 5 times)
+    for (let craft = 0; craft < 5; craft++) {
       // Consume 2 ingredients
       let consumed = 0;
       inventory = inventory.filter(item => {
@@ -377,7 +380,7 @@ describe('Core Gameplay Loop', () => {
       });
 
       // Add more ingredients for next cycle
-      if (craft < 3) {
+      if (craft < 4) {
         for (let i = 0; i < 2; i++) {
           inventory.push({ label: 'Ingredient', type: 'ingredient' });
         }
@@ -389,7 +392,7 @@ describe('Core Gameplay Loop', () => {
     }
 
     // Install all components
-    while (inventory.some(i => i.type === 'component') && systemsInstalled < 4) {
+    while (inventory.some(i => i.type === 'component') && systemsInstalled < 5) {
       let installed = false;
       inventory = inventory.filter(item => {
         if (!installed && item.type === 'component') {
@@ -402,8 +405,8 @@ describe('Core Gameplay Loop', () => {
     }
 
     // Launch
-    expect(systemsInstalled).toBe(4);
-    expect(xp).toBe(60);
+    expect(systemsInstalled).toBe(5);
+    expect(xp).toBe(75);
     expect(timeLeft).toBe(3600);
   });
 });

--- a/tests/game-scenes.test.js
+++ b/tests/game-scenes.test.js
@@ -245,12 +245,12 @@ describe('Game State Transitions', () => {
     const isWin = (registry) => {
       const installed = registry.get('systemsInstalled');
       const time = registry.get('timeLeft');
-      return installed >= 4 && time > 0;
+      return installed >= 5 && time > 0;
     };
 
     expect(isWin(registry)).toBe(false);
 
-    registry.set('systemsInstalled', 4);
+    registry.set('systemsInstalled', 5);
     expect(isWin(registry)).toBe(true);
 
     registry.set('timeLeft', 0);
@@ -363,11 +363,14 @@ describe('Crafting & Installation State', () => {
 
     registry.set('systemsInstalled', 4);
     expect(registry.get('systemsInstalled')).toBe(4);
+
+    registry.set('systemsInstalled', 5);
+    expect(registry.get('systemsInstalled')).toBe(5);
   });
 
   it('completes full craft+install sequence', () => {
-    // Simulate 4 craft cycles + 4 install cycles
-    for (let i = 0; i < 4; i++) {
+    // Simulate 5 craft cycles + 5 install cycles
+    for (let i = 0; i < 5; i++) {
       // Craft a component
       let inventory = registry.get('inventory');
       inventory.push({ label: `System${i}`, type: 'component' });
@@ -381,7 +384,7 @@ describe('Crafting & Installation State', () => {
       registry.set('systemsInstalled', i + 1);
     }
 
-    expect(registry.get('systemsInstalled')).toBe(4);
+    expect(registry.get('systemsInstalled')).toBe(5);
     expect(registry.get('inventory')).toHaveLength(0);
   });
 });
@@ -444,7 +447,8 @@ describe('Multi-State Coordination', () => {
     registry.set('systemsInstalled', 2);
     registry.set('systemsInstalled', 3);
     registry.set('systemsInstalled', 4);
+    registry.set('systemsInstalled', 5);
 
-    expect(actions).toEqual(['installed-1', 'installed-2', 'installed-3', 'installed-4']);
+    expect(actions).toEqual(['installed-1', 'installed-2', 'installed-3', 'installed-4', 'installed-5']);
   });
 });


### PR DESCRIPTION
Closes #91

## Summary
- **workbench.js** — Added `Pressure Regulator` as the 5th recipe (tint `0xff44aa`, 15 XP); completion guard `4→5`
- **rocket.js** — Added 6th TINT (hot pink `0xff44aa` at 4/5, gold `0xffee44` at 5/5); all launch thresholds `>= 4 → >= 5`; JSDoc updated
- **hud.js** — Counter display `0/4 → 0/5`; cyan glow threshold `n >= 4 → n >= 5`
- **achievement_manager.js** — `all_systems` check updated to `value >= 5`; comment updated
- **searchable_container.js** — PVC Coupler promoted `junk → ingredient` in `default` + `cooler` loot tables, enabling it as a crafting input
- **tests** — `ROCKET_SYSTEMS` arrays updated with 5th entry; all loop bounds, XP totals (`60→75`), array lengths, and achievement threshold tests corrected

## Test plan
- [ ] 391/391 unit tests pass
- [ ] Workbench correctly offers Pressure Regulator as the 5th craft (after 4 systems built)
- [ ] Rocket prompt stays `[E] Install` until 5th system installed, then flips to `[E] Launch`
- [ ] HUD counter shows `0/5` → `5/5` (cyan on completion)
- [ ] `★ LAUNCH READY` achievement fires at 5 systems, not 4
- [ ] PVC Coupler appears as a craftable ingredient
- [ ] Rocket tint progression: grey → warm → warmer → almost → hot pink → gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)