### PR TITLE
docs: adopt TDD workflow across all agent instructions and CLAUDE.md (#138)

### DIFF
--- a/.claude/AGENT_INSTRUCTIONS.md
+++ b/.claude/AGENT_INSTRUCTIONS.md
@@ -39,7 +39,9 @@ Close issue: "✅ Merged to main (commit: SHA)"
 ```
 
 ### Definition of Done
-- ✅ Code written & tested
+- ✅ **Tests written first** against SPEC acceptance criteria ← TDD REQUIREMENT
+- ✅ Tests fail before implementation (verified)
+- ✅ Code written & all tests pass
 - ✅ All acceptance criteria met
 - ✅ PR created with clear description
 - ✅ **Human reviewed and approved** ← REQUIRED
@@ -110,9 +112,10 @@ GitHub will block self-merges. This is enforced at the repository level — not 
    - Features: `git checkout -b feature/issue-X-description`
    - Bugs:     `git checkout -b fix/issue-X-description`
    - Docs:     `git checkout -b docs/issue-X-description`
-5. **Work** and post progress updates
-6. **Create a PR** and post "📋 PR #N ready for human review"
-7. **Wait** — do not merge. Do not close the issue.
+5. **Write failing tests first** — before any implementation (see TDD Workflow below)
+6. **Implement** — make the tests pass
+7. **Create a PR** and post "📋 PR #N ready for human review"
+8. **Wait** — do not merge. Do not close the issue.
 
 > **Every change — features, bug fixes, docs — goes through a branch and PR.**
 > Nothing is committed directly to `main`.
@@ -256,5 +259,53 @@ Post on the issue: `"📋 PR #N ready for human review — waiting for approval"
 
 ---
 
-**Last Updated**: 2026-03-08
+---
+
+## 🧪 TDD Workflow (MANDATORY)
+
+This project uses **test-driven development**. Tests are always written before implementation.
+
+### The TDD cycle
+
+```
+Read SPEC acceptance criteria
+  ↓
+Write failing tests (unit + E2E stubs)
+  ↓
+Verify tests FAIL (a passing test before implementation tests nothing)
+  ↓
+Implement the minimum code to make tests pass
+  ↓
+Refactor with tests as safety net
+  ↓
+All tests green → open PR
+```
+
+### Who writes the tests?
+
+- **qa-eng** writes the failing test suite for a feature based on SPEC acceptance criteria
+- **The implementing agent** (ux-game-designer or general) writes code to make those tests pass
+- For solo work, write the tests first in the same branch before any implementation
+
+### What kind of tests, and where?
+
+| Behaviour | Test type | File pattern | Tool |
+|-----------|-----------|--------------|------|
+| Pure game logic (XP values, phase boundaries, loot weights) | Unit | `tests/*.test.js` | Vitest |
+| Registry state + scene coordination | Unit (mock-registry) | `tests/game-scenes.test.js` | Vitest |
+| Phaser scene rendering + player input | E2E | `tests/*.e2e.js` | Playwright |
+
+**Critical constraint**: never import `src/gameobjects/*.js` or `src/scenes/*.js` in Vitest — they extend Phaser classes and throw in jsdom. Extract pure logic to standalone modules first, then test those.
+
+### Inlined constants rule
+
+When a test inlines constants from source files (e.g. `NPC_CONFIGS`, `ROCKET_SYSTEMS`), add:
+```js
+// inlined from src/gameobjects/npc.js — keep in sync
+```
+And treat a sync failure as a **test bug** to fix immediately — it silently masks regressions.
+
+---
+
+**Last Updated**: 2026-04-11
 **Mandatory for**: All agents

--- a/.claude/GITHUB_ISSUES_WORKFLOW.md
+++ b/.claude/GITHUB_ISSUES_WORKFLOW.md
@@ -76,6 +76,10 @@ gh pr create --title "feat: implement NPC system (#12)" \
 ## Changes
 - [list key changes]
 
+## Tests Written First
+- [x] Unit tests written and failing before implementation
+- [x] E2E stubs added for Phaser-dependent behaviour
+
 ## Acceptance Criteria
 - [x] Criterion 1
 - [x] Criterion 2
@@ -134,15 +138,17 @@ TODO.md updated. Changes are now in production on main branch."
 
 A work item is **ONLY complete** when:
 
-1. ✅ Code is written and tested locally
-2. ✅ All acceptance criteria are met
-3. ✅ PR is created with a clear description
-4. ✅ **Human has reviewed and approved the PR**
-5. ✅ **Human has merged PR to main** ← CRITICAL (agents do not self-merge)
-6. ✅ **TODO.md updated** — task marked ✅ with commit hash
-7. ✅ Issue is closed with final comment linking the merged commit
+1. ✅ **Failing tests written first** against SPEC acceptance criteria ← TDD REQUIREMENT
+2. ✅ Tests verified to fail before implementation
+3. ✅ Code written and all tests pass
+4. ✅ All acceptance criteria are met
+5. ✅ PR is created with a clear description
+6. ✅ **Human has reviewed and approved the PR**
+7. ✅ **Human has merged PR to main** ← CRITICAL (agents do not self-merge)
+8. ✅ **TODO.md updated** — task marked ✅ with commit hash
+9. ✅ Issue is closed with final comment linking the merged commit
 
-**⚠️ CRITICAL: Agents must not merge their own PRs. Do NOT close the issue until step 5 is complete.**
+**⚠️ CRITICAL: Agents must not merge their own PRs. Do NOT close the issue until step 7 is complete.**
 
 If the PR is closed/abandoned before merging, **reopen** the issue and update its status.
 
@@ -298,5 +304,6 @@ Refer to this document first. If unclear, ask in the issue comments and wait for
 
 ---
 
-**Last Updated**: 2026-03-08 (added human-in-the-loop PR review requirement)
+**Last Updated**: 2026-04-11 (adopted TDD — tests written before implementation)
+**Maintained by**: DevOps Agent + all team members
 **Maintained by**: DevOps Agent + all team members

--- a/.claude/agent-memory/qa-eng/MEMORY.md
+++ b/.claude/agent-memory/qa-eng/MEMORY.md
@@ -7,11 +7,17 @@
 - `window.game` is set in `src/main.js` (line 43) after Phaser init
 
 ## Test Infrastructure
-- Unit tests: `vitest run` → `tests/*.test.js` (201 tests, all green as of task 4.2)
-- E2E tests: `playwright test` → `tests/*.e2e.js` — currently can't run (browsers not installed)
-- Playwright browsers must be installed separately: `npx playwright install`
+- Unit tests: `vitest run` → `tests/*.test.js` (391 tests as of PRs #133/#134 merge, all green)
+- E2E tests: `playwright test` → `tests/*.e2e.js` (13 tests, all pass after `npx playwright install chromium`)
+- Playwright browsers must be installed separately: `npx playwright install chromium`
+- `node_modules` may be absent after a fresh clone/pull — run `npm install` before any test run
 - **E2E tests are NOT wired into CI/CD** — `deploy.yml` only runs `npm test` (unit tests)
 - Vitest excludes `src/scenes/*.js` from coverage tracking
+
+## ⚠️ Stale Inlined Constants Risk
+- `npc-logic.test.js` inlines `NPC_CONFIGS` but was not updated when PR #133 changed quest reward XP from 30/40/35 → 200 for all NPCs. Tests still passed because assertions use `NPC_CONFIGS.harvey.quest.reward.xp` (self-referential), not the literal source value.
+- The `// inlined from X.js — keep in sync` comment is the only enforcement — it is **not machine-checked**.
+- When inlining constants: always use the literal value in at least one assertion so a sync failure causes a real test failure. Never write `expect(INLINED_CONST).toBe(INLINED_CONST)` — that tests nothing.
 
 ## Known Issues in E2E Tests (game-flow.e2e.js)
 See `e2e-issues.md` for full detail. Key problems:

--- a/.claude/agents/qa-eng.md
+++ b/.claude/agents/qa-eng.md
@@ -1,14 +1,19 @@
 ---
 name: qa-eng
-description: "Use this agent when you need comprehensive testing coverage including unit tests, end-to-end tests, integration tests, or any quality assurance work. This agent should be invoked proactively whenever code is written, features are completed, or before deployment. Examples: after implementing a game mechanic, use the qa agent to run full test suite and validate behavior; when fixing a bug, use the qa agent to verify the fix and check for regressions; before merging to main, use the qa agent to perform comprehensive testing."
+description: "Use this agent when you need comprehensive testing coverage including unit tests, end-to-end tests, integration tests, or any quality assurance work. This agent should be invoked proactively whenever code is written, features are completed, or before deployment. Examples: BEFORE implementing a feature, use the qa agent to write failing tests from the SPEC; after implementing a game mechanic, use the qa agent to run the full test suite and validate behavior; when fixing a bug, use the qa agent to verify the fix and check for regressions; before merging to main, use the qa agent to perform comprehensive testing."
 model: sonnet
 color: pink
 memory: project
 ---
 
-You are QA, an elite quality assurance expert specializing in comprehensive testing for game development. You possess deep expertise in the game's framework and entire tech stack, and you maintain exacting standards that prioritize code quality and stability above all else.
+You are QA, an elite quality assurance expert specializing in test-driven development for game development. You possess deep expertise in the game's framework and entire tech stack, and you maintain exacting standards that prioritize test-first discipline and code quality above all else.
+
+## TDD is the law
+
+**Tests are written before implementation — always.** Your primary role is to write failing tests based on SPEC acceptance criteria so that implementing agents have a clear, executable contract to satisfy. A test that is written after implementation and passes on the first run proves nothing.
 
 Your Core Responsibilities:
+- **Write failing tests first** — read SPEC acceptance criteria, translate them into Vitest unit tests and Playwright E2E stubs, verify they fail, then hand off to the implementing agent
 - Design and execute comprehensive test strategies covering unit tests, integration tests, and end-to-end tests
 - Identify bugs, performance issues, edge cases, and architectural problems with uncompromising rigor
 - Provide brutally honest assessments of code quality without softening criticism for developer feelings
@@ -16,7 +21,8 @@ Your Core Responsibilities:
 - Validate that implementations meet technical specifications and best practices
 
 Your Testing Approach:
-- Execute all relevant test suites (unit, integration, e2e) for code changes
+- **Before implementation**: write the failing test suite from SPEC acceptance criteria
+- **After implementation**: run the full suite, confirm all new tests pass, confirm no regressions
 - Test edge cases, boundary conditions, and error scenarios thoroughly — including UX edge cases surfaced by the ux-game-designer (e.g., rapid E-presses, zone transition mid-interaction)
 - Validate performance characteristics and profile rendering against budgets defined by the ux-game-designer
 - Check for regressions in existing functionality
@@ -24,7 +30,35 @@ Your Testing Approach:
 - Validate that visual feedback (XP popups, screen shake, particle effects) fires correctly at the right game moments
 - Test platform-specific behaviors and compatibility issues
 
-When the ux-game-designer has proposed a feature, use their acceptance criteria and edge case list as your test specification. QA validates against requirements — it does not redefine them.
+When the ux-game-designer has proposed a feature, use their acceptance criteria and edge case list as your test specification. QA defines the contract — it does not redefine requirements, but it owns the executable proof that they are met.
+
+## TDD workflow for this codebase
+
+### Step 1 — Identify what can be unit-tested
+Pure logic (XP values, phase boundaries, loot weights, recipe sequences, hazard thresholds) must be extracted to standalone modules with no Phaser imports before writing tests. If the logic lives inside a Phaser class, request that it be extracted first.
+
+**Phaser import boundary**: never import `src/gameobjects/*.js` or `src/scenes/*.js` in Vitest — Phaser is undefined in jsdom. Safe to import: `storm_phase_logic.js`, `flood_zone.js` (constants only), and any module you extract that has zero Phaser class inheritance.
+
+### Step 2 — Write unit tests (Vitest)
+- File: `tests/<system>.test.js`
+- Test every acceptance criterion as a named `it()` block
+- Use inline mock-registry pattern for scene-level state tests (see `tests/game-scenes.test.js`)
+- Inline constants from source with `// inlined from X.js — keep in sync` comment
+- Run `npm test` — **all new tests must fail at this point**
+
+### Step 3 — Write E2E stubs (Playwright)
+- File: `tests/game-flow.e2e.js`
+- Add `test.skip('...')` stubs for any Phaser-dependent acceptance criteria
+- These become real tests once implementation is complete
+
+### Step 4 — Hand off to implementing agent
+Share the failing test file. The implementing agent writes code to make the tests pass. You review the PR.
+
+### Step 5 — Review the implementation PR
+- Run the full suite: `npm test && npm run test:e2e`
+- Confirm all tests that were failing now pass
+- Confirm no regressions (previously passing tests still pass)
+- Check that inlined constants in tests match source file values exactly
 
 Your Communication Style:
 - Be direct and specific about failures - vague praise is meaningless

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,31 @@ node scripts/generate-juan-sprite.js # → public/assets/images/player.png
 
 Scripts use ESM (`import`) and pure Node.js (no npm dependencies beyond zlib). Do not edit the output files by hand.
 
+### Test-Driven Development
+
+**This project uses TDD. Tests are written before implementation — always.**
+
+The workflow for every feature or bug fix:
+
+1. **Read the SPEC** — identify the acceptance criteria for what you're building
+2. **Write failing tests first** — unit tests for pure logic, E2E stubs for Phaser-dependent behaviour
+3. **Verify tests fail** — a test that passes before implementation tests nothing
+4. **Implement** — write the minimum code to make the tests pass
+5. **Refactor** — clean up with tests as the safety net
+
+**qa-eng writes the failing tests. The implementing agent makes them pass.**
+When a feature spans both agents, qa-eng opens a test PR first; the feature PR merges after.
+
+For pure-logic systems (storm phases, XP values, loot tables, hazard thresholds):
+- Extract logic to a standalone module with no Phaser imports
+- Write Vitest unit tests against that module before writing any Phaser-dependent code
+- The extracted module IS the spec contract — tests lock its behaviour
+
+For Phaser-dependent behaviour (scenes, game objects, cameras):
+- Write Playwright E2E stubs that describe the expected player-facing outcome
+- These stubs fail or skip until the implementation is complete
+- Scene-level unit tests use the mock-registry pattern (see `tests/game-scenes.test.js`)
+
 ### Testing Constraints
 
 **Never import `src/gameobjects/*.js` or `src/scenes/*.js` directly in Vitest tests.** These files extend Phaser classes, which throws `ReferenceError: Phaser is not defined` in jsdom. Instead:


### PR DESCRIPTION
Closes #138

## Summary
Embeds TDD-first workflow into every layer of agent documentation so that tests are always written before implementation — not as an afterthought.

This branch had been created during the previous session but lost its changes due to context compaction. All intended changes are now committed.

## Changes

### `CLAUDE.md`
- New **"Test-Driven Development"** section under Asset Generation with the 5-step TDD cycle, who writes tests (qa-eng), and unit vs E2E guidance

### `.claude/AGENT_INSTRUCTIONS.md`
- **Definition of Done**: expanded from 7 to 9 steps — "Tests written first (TDD)" is now step 1
- **Before Starting**: step 5 changed from "Work and post progress updates" to "Write failing tests first"
- **New TDD Workflow section** appended: full cycle diagram, who writes tests, test-type table, Phaser import boundary rule, inlined constants rule

### `.claude/GITHUB_ISSUES_WORKFLOW.md`
- **PR description template**: new "Tests Written First" checklist block
- **Definition of Done**: 7→9 items with TDD as first requirement
- **Date updated**: `2026-03-08 → 2026-04-11 (adopted TDD)`

### `.claude/agents/qa-eng.md`
- **Description**: BEFORE implementing, write failing tests from SPEC
- **Intro**: reframed as TDD-first agent
- **"TDD is the law"** heading + mandate explanation
- **5-step TDD workflow** (identify → unit tests → E2E stubs → hand off → review PR)

### `.claude/agent-memory/qa-eng/MEMORY.md`
- Test counts: 201 → 391 (current)
- Added stale inlined constants warning with the NPC_CONFIGS example

## Test plan
- [x] 391/391 unit tests pass (docs-only change, no test changes)
- [x] All 5 changed files are documentation only — no source or test file changes
- [x] No merge conflict with `feature/issue-91-111-rocket-5th-system-partial-launch` (PR #137) — disjoint file sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)