### PR TITLE
docs: finish Kiro steering migration + record 9.1.1 lightning

### DIFF
--- a/.kiro/agent-memory/qa-eng/MEMORY.md
+++ b/.kiro/agent-memory/qa-eng/MEMORY.md
@@ -14,6 +14,32 @@
 - **E2E tests are NOT wired into CI/CD** — `deploy.yml` only runs `npm test` (unit tests)
 - Vitest excludes `src/scenes/*.js` from coverage tracking
 
+## ⚠️ `npm run build` prints "Done" even when it FAILS
+Confirmed 2026-07-24. The build script is `vite build --config vite/config.prod.mjs`, and
+`✨ Done ✨` is emitted before rollup reports a parse error. Grepping output for "Done" will
+report a green build on genuinely broken source.
+
+**Always check the exit code, never the output text.** In PowerShell a pipeline clobbers
+`$LASTEXITCODE`, so redirect instead of piping:
+```powershell
+npm run build *> build.log
+if ($LASTEXITCODE -ne 0) { "BUILD FAILED" }
+```
+Verified: exit 1 on a syntax error, exit 0 when clean.
+
+## ⚠️ A syntactically broken scene file passes `npm test`
+Because Vitest never imports `src/scenes/*.js` or Phaser-extending game objects, a missing
+brace in `hud.js` or `game.js` is invisible to the entire 700+ test unit suite. Unit tests
+are NOT a syntax gate for scene files. Use `npm run build` (exit code) or
+`npx esbuild <file> --outfile=<tmp>` to parse-check scene files directly.
+
+## ⚠️ Merge-marker stripping drops factored-out closing braces
+When two branches insert new methods at the same location in a class, git factors the
+trailing `}` of the preceding method out of the conflict region as a common suffix.
+Resolving by deleting only the `<<<<<<<` / `=======` / `>>>>>>>` lines then leaves the file
+one `}` short and silently merges two method bodies. After any keep-both resolution inside
+a class body, parse-check the file and compare `{` / `}` counts.
+
 ## ⚠️ Stale Inlined Constants Risk
 - `npc-logic.test.js` inlines `NPC_CONFIGS` but was not updated when PR #133 changed quest reward XP from 30/40/35 → 200 for all NPCs. Tests still passed because assertions use `NPC_CONFIGS.harvey.quest.reward.xp` (self-referential), not the literal source value.
 - The `// inlined from X.js — keep in sync` comment is the only enforcement — it is **not machine-checked**.

--- a/.kiro/agent-memory/ux-game-designer/MEMORY.md
+++ b/.kiro/agent-memory/ux-game-designer/MEMORY.md
@@ -91,6 +91,24 @@ the wrong branch.
 **Fix**: always isolate subagents that will use git in their own worktree/checkout
 (a temp directory), so each agent has a fully isolated working copy.
 
+**Kiro's `subagent` tool has NO `isolation` parameter** — you must build the isolation
+yourself. Confirmed working 2026-07-24 across 7 features built in parallel:
+
+1. Orchestrator creates one worktree per feature, each on its own branch:
+   `git worktree add -b feature/issue-N-slug ../swampfire-wt/wtN main`
+2. Junction `node_modules` into each worktree so Vitest/Vite run without reinstalling:
+   `New-Item -ItemType Junction -Path <wt>\node_modules -Target <repo>\node_modules`
+3. Every subagent prompt names the absolute worktree path and says
+   **"RUN NO GIT COMMANDS AT ALL"**. The orchestrator alone runs add/commit/push/PR.
+4. For dependent features, branch off the prerequisite (not main) and open a
+   **stacked PR**: `gh pr create --base <prereq-branch>`. Keeps the diff reviewable.
+
+Result: zero cross-branch contamination. Verify with `git worktree list` and
+`git log --oneline --all --graph` before trusting any parallel run.
+
+Also learned: CI security scans only trigger on PRs targeting `main`, so stacked PRs
+show no checks until their base merges — cite local `npm test` + `npm run build` instead.
+
 If worktree isolation isn't used and branches get cross-contaminated, check
 `git branch --show-current` before every commit, and `git log --oneline --all --graph`
 to see where commits actually landed.

--- a/.kiro/agent-memory/ux-game-designer/MEMORY.md
+++ b/.kiro/agent-memory/ux-game-designer/MEMORY.md
@@ -136,10 +136,10 @@ Branch protection on main requires 1 approving review — GitHub blocks self-mer
 Always comment on the issue at the START of work, not just at the end.
 
 ### TODO.md update rule (MANDATORY — learned 2026-03-08)
-**TODO.md must be committed inside the feature PR — not as a separate step after merge.**
+**TODO.md must be committed inside the feature PR.**
 - Stage `TODO.md` alongside the feature files before `git commit`
 - Mark the task ✅ with the commit hash in the same commit
-- Never leave TODO.md as an unstaged local edit after a merge — it will drift from reality
+- Never leave TODO.md as an unstaged local edit — it will drift from reality
 - Direct pushes to main bypass branch protection and generate a GitHub warning; avoid them
 
 ### Definition of Done checklist (per task)

--- a/.kiro/steering/agent-instructions.md
+++ b/.kiro/steering/agent-instructions.md
@@ -25,6 +25,8 @@ Make progress
   ↓
 Post updates: "✅ Completed X, working on Y..."
   ↓
+Update TODO.md: change ⏳ → ✅, add commit hash _(abc1234)_ — commit with the feature
+  ↓
 Push to feature branch & create PR
   ↓
 Post comment: "📋 PR #123 ready for human review — waiting for approval"
@@ -32,8 +34,6 @@ Post comment: "📋 PR #123 ready for human review — waiting for approval"
 ⏸️  STOP — do not merge. A human reviews and approves the PR.
   ↓
 Human merges PR to main
-  ↓
-Update TODO.md: change ⏳ → ✅, add commit hash _(abc1234)_
   ↓
 Close issue: "✅ Merged to main (commit: SHA)"
 ```
@@ -43,13 +43,13 @@ Close issue: "✅ Merged to main (commit: SHA)"
 - ✅ Tests fail before implementation (verified)
 - ✅ Code written & all tests pass
 - ✅ All acceptance criteria met
+- ✅ **TODO.md updated** — task marked ✅ with commit hash, committed in the feature PR
 - ✅ PR created with clear description
 - ✅ **Human reviewed and approved** ← REQUIRED
 - ✅ **PR merged to main by human** ← CRITICAL
-- ✅ **TODO.md updated** — task marked ✅ with commit hash ← REQUIRED
 - ✅ **GitHub issue closed** with commit/PR link ← REQUIRED
 
-**Do not merge your own PRs. Do not close issues or update TODO.md until a human has merged the PR.**
+**Do not merge your own PRs. Do not close issues until a human has merged the PR.**
 
 ### Example Issue Comment After PR Creation
 
@@ -129,7 +129,7 @@ GitHub will block self-merges. This is enforced at the repository level — not 
 
 - **Never merge your own PR** — human approval is required
 - **Create a PR, then stop** — leave merging to the human
-- **Update TODO.md when done** — mark ✅, add commit hash, after merge
+- **Update TODO.md when done** — mark ✅, add commit hash, commit inside the feature PR
 - **Update issues regularly** — don't go silent for hours
 - **Link PRs to issues** — "Closes #XX" in PR description
 - **Close with evidence** — include commit/PR link in closure comment, AFTER merge
@@ -242,9 +242,9 @@ Post on the issue: `"📋 PR #N ready for human review — waiting for approval"
 
 ⏸️ **STOP** — do not merge. Wait for human approval.
 
-### Step 4 — After human merges: mark done in both places
-- TODO.md `## Bugs` section: `⏳` → `✅` with commit hash
-- GitHub issue: close with evidence comment
+### Step 4 — After human merges: close the issue
+- TODO.md `## Bugs` section: `⏳` → `✅` with commit hash — **committed inside the fix PR**
+- GitHub issue: close with evidence comment (only after human merges)
 
 ### What makes a good bug issue
 - **Root cause** — not just symptoms. Identify the exact line(s) responsible.

--- a/.kiro/steering/agent-instructions.md
+++ b/.kiro/steering/agent-instructions.md
@@ -96,7 +96,10 @@ GitHub will block self-merges. This is enforced at the repository level — not 
 | Need | Location |
 |------|----------|
 | **Issue workflow details** | `.kiro/steering/github-issues-workflow.md` |
-| **GitHub CLI commands** | `.kiro/steering/github-issues-workflow.md` → "Tools & Commands" |
+| **GitHub CLI commands** | `.kiro/steering/github-quick-reference.md` |
+| **Project board usage** | `.kiro/steering/project-board-setup.md` |
+| **Milestones & phases** | `.kiro/steering/milestones.md` |
+| **Architecture & commands** | `.kiro/steering/project-reference.md` |
 | **Phase descriptions** | `TODO.md` (links to all issues) |
 | **DevOps practices** | `.kiro/agent-memory/devops/MEMORY.md` |
 | **Game design specs** | `SPEC.md` |

--- a/.kiro/steering/github-issues-workflow.md
+++ b/.kiro/steering/github-issues-workflow.md
@@ -117,16 +117,14 @@ If the human requests changes, address the feedback, push new commits, and updat
 Ready for re-review.
 ```
 
-### 5. **Update TODO.md + Close the Issue (FINAL STEP — after human merges)**
+### 5. **Update TODO.md (in the feature PR) + Close the Issue (after human merges)**
 
-**ONLY after the change is merged to main:**
-
-First, update `TODO.md` — find the task, change `⏳` to `✅`, and append the commit hash:
+Update `TODO.md` **before opening the PR** — find the task, change `⏳` to `✅`, and append the commit hash. Stage it alongside your feature files:
 ```markdown
 - ✅ **3.X Task name** [#N](url) _(abc1234)_
 ```
 
-Then close the GitHub issue:
+Then, **only after the human merges the PR to main**, close the GitHub issue:
 ```bash
 gh issue close ISSUE_NUMBER --comment "✅ Completed and merged to main (commit: [SHA])
 
@@ -148,13 +146,13 @@ A work item is **ONLY complete** when:
 2. ✅ Tests verified to fail before implementation
 3. ✅ Code written and all tests pass
 4. ✅ All acceptance criteria are met
-5. ✅ PR is created with a clear description
-6. ✅ **Human has reviewed and approved the PR**
-7. ✅ **Human has merged PR to main** ← CRITICAL (agents do not self-merge)
-8. ✅ **TODO.md updated** — task marked ✅ with commit hash
+5. ✅ **TODO.md updated** — task marked ✅ with commit hash, committed in the feature PR
+6. ✅ PR is created with a clear description
+7. ✅ **Human has reviewed and approved the PR**
+8. ✅ **Human has merged PR to main** ← CRITICAL (agents do not self-merge)
 9. ✅ Issue is closed with final comment linking the merged commit
 
-**⚠️ CRITICAL: Agents must not merge their own PRs. Do NOT close the issue until step 7 is complete.**
+**⚠️ CRITICAL: Agents must not merge their own PRs. Do NOT close the issue until step 8 is complete.**
 
 If the PR is closed/abandoned before merging, **reopen** the issue and update its status.
 

--- a/.kiro/steering/github-quick-reference.md
+++ b/.kiro/steering/github-quick-reference.md
@@ -1,0 +1,130 @@
+---
+inclusion: manual
+---
+
+# GitHub Issues - Quick Reference Card
+
+**Keep this open while working.**
+
+---
+
+## 🔴 GOLDEN RULE
+
+**Work is done ONLY when merged to main. Do NOT close issues until then.**
+
+---
+
+## 📋 Checklist When Starting
+
+- [ ] Find issue #XX in `TODO.md` or `gh issue list`
+- [ ] Read issue description & acceptance criteria
+- [ ] Post comment: `🚀 Starting work`
+- [ ] Create branch: `git checkout -b feature/issue-X-description`
+
+---
+
+## 💻 While Working
+
+**Every 1-2 hours, post a progress comment:**
+
+```
+✅ [What's done]
+⏳ [What's next]
+🚧 [Any blockers?]
+```
+
+---
+
+## ✅ When Code is Ready
+
+### 1. Push Branch
+```bash
+git add .
+git commit -m "feat: [description] (#ISSUE_NUMBER)"
+git push -u origin feature/issue-X-description
+```
+
+### 2. Create PR
+```bash
+gh pr create --title "feat: [description] (#ISSUE_NUMBER)" \
+  --body "Closes #ISSUE_NUMBER
+
+## Acceptance Criteria
+- [x] Done
+- [x] Done"
+```
+
+### 3. Update Issue
+```
+📋 PR #[PR_NUMBER] created and ready for review
+```
+
+### 4. STOP — Wait for Human Review
+
+**Do NOT merge.** A human must review and approve.
+
+---
+
+## 🎯 After Human Merges
+
+### 1. Update TODO.md
+Change `⏳` → `✅` and add commit hash.
+
+### 2. Close Issue
+```bash
+gh issue close ISSUE_NUMBER --comment "✅ Merged to main (commit: SHA)
+
+All acceptance criteria met:
+- [x] Criterion 1
+- [x] Criterion 2"
+```
+
+---
+
+## 🚨 Common Mistakes
+
+| ❌ Don't | ✅ Do |
+|---|---|
+| Merge your own PR | Wait for human approval |
+| Close issue before merge | Close only after PR is on main |
+| Go silent during development | Post progress updates hourly |
+| Commit without linking issue | Use "Closes #XX" in PR |
+| Close unmerged PR | Reopen issue, fix, and retry |
+
+---
+
+## 📌 Key Commands
+
+```bash
+# View your assigned issues
+gh issue list --assignee @me
+
+# View single issue
+gh issue view #12
+
+# Add comment
+gh issue comment #12 --body "Update message"
+
+# Create PR
+gh pr create --title "Title (#12)" --body "Details"
+
+# Close issue (ONLY after human merges PR)
+gh issue close #12 --comment "Message"
+
+# Reopen issue
+gh issue reopen #12
+
+# Check PR status
+gh pr view PR_NUMBER
+gh pr checks PR_NUMBER
+```
+
+---
+
+## 🎓 More Details?
+
+Read: `.kiro/steering/github-issues-workflow.md`
+
+---
+
+**Remember**: Merged to main = done. Closed issue = in production.

--- a/.kiro/steering/github-quick-reference.md
+++ b/.kiro/steering/github-quick-reference.md
@@ -67,10 +67,7 @@ gh pr create --title "feat: [description] (#ISSUE_NUMBER)" \
 
 ## 🎯 After Human Merges
 
-### 1. Update TODO.md
-Change `⏳` → `✅` and add commit hash.
-
-### 2. Close Issue
+### 1. Close Issue
 ```bash
 gh issue close ISSUE_NUMBER --comment "✅ Merged to main (commit: SHA)
 
@@ -78,6 +75,8 @@ All acceptance criteria met:
 - [x] Criterion 1
 - [x] Criterion 2"
 ```
+
+> **Note:** TODO.md should already be updated (✅ + commit hash) inside the feature PR — not after merge.
 
 ---
 

--- a/.kiro/steering/milestones.md
+++ b/.kiro/steering/milestones.md
@@ -1,0 +1,189 @@
+---
+inclusion: manual
+---
+
+# GitHub Milestones - Swampfire Protocol
+
+**Date**: 2026-03-08
+**Status**: ✅ Created and assigned
+
+---
+
+## Overview
+
+GitHub Milestones organize the 17 development issues into 5 release phases. Each milestone represents a distinct development phase with clear dependencies.
+
+---
+
+## Milestones
+
+### 📌 Phase 3 - World Building (4 issues)
+**Status**: Backlog
+**Issues**: #2, #3, #4, #5
+
+| Issue | Title |
+|-------|-------|
+| #2 | 3.1 Zone 0 tilemap (Cypress Creek Preserve) |
+| #3 | 3.2 Zone manager + zone transitions |
+| #4 | 3.3 Zone 1 tilemap (US-41 corridor) |
+| #5 | 3.4 Remaining zones (2, 3, 4) |
+
+**Goal**: Build complete world map with 5 explorable zones and smooth transitions.
+
+---
+
+### 📌 Phase 4 - Storm & Hazards (3 issues)
+**Status**: Backlog
+**Issues**: #6, #7, #8
+**Depends on**: Phase 3 complete
+
+| Issue | Title |
+|-------|-------|
+| #6 | 4.1 Storm phase system |
+| #7 | 4.2 Hazard game objects |
+| #8 | 4.3 Wind + environmental effects |
+
+**Goal**: Add dynamic weather, hazards, and environmental effects that intensify over time.
+
+---
+
+### 📌 Phase 5 - Feedback & Polish (4 issues)
+**Status**: Backlog
+**Issues**: #9, #10, #11, #12
+**Depends on**: Phase 4 complete
+
+| Issue | Title |
+|-------|-------|
+| #9 | 5.1 XP popup system |
+| #10 | 5.2 Combo streak system |
+| #11 | 5.3 Audio overhaul |
+| #12 | 5.4 NPC system |
+
+**Goal**: Add visual/audio feedback, combo mechanics, and character interactions.
+
+---
+
+### 📌 Phase 6 - Endgame & Meta (3 issues)
+**Status**: Backlog
+**Issues**: #13, #14, #15
+**Depends on**: Phase 5 complete
+
+| Issue | Title |
+|-------|-------|
+| #13 | 6.1 Launch sequence |
+| #14 | 6.2 End-of-run share card |
+| #15 | 6.3 Achievement toasts |
+
+**Goal**: Complete victory flow, share features, and achievement system.
+
+---
+
+### 📌 Cleanup & Maintenance (3 issues)
+**Status**: Anytime (low priority)
+**Issues**: #16, #17, #18
+
+| Issue | Title |
+|-------|-------|
+| #16 | Cleanup: Remove unused assets |
+| #17 | Cleanup: Remove unused game objects |
+| #18 | Cleanup: Remove @mikewesthad/dungeon dependency |
+
+**Goal**: Remove technical debt and deprecated code (after replacements exist).
+
+---
+
+## How to Use Milestones
+
+### View Milestones
+```bash
+# List all milestones
+gh api repos/m3ssana/swampfire/milestones -q '.[] | "\(.title): \(.open_issues) open"'
+
+# View milestone progress
+# https://github.com/m3ssana/swampfire/milestones
+```
+
+### Filter Issues by Milestone
+```bash
+# View all issues in Phase 3
+gh issue list --milestone "Phase 3 - World Building"
+
+# View issues across all milestones
+gh issue list
+```
+
+### Update Issue Milestone
+```bash
+# Assign issue to milestone
+gh issue edit #2 --milestone "Phase 3 - World Building"
+
+# Remove from milestone
+gh issue edit #2 --milestone ""
+```
+
+### Track Milestone Progress
+Visit: https://github.com/m3ssana/swampfire/milestones
+
+Each milestone shows:
+- ✅ Completed issues
+- 🔄 Open issues
+- 📊 Progress bar
+- 📅 Due date (optional)
+
+---
+
+## Workflow Integration
+
+### When Starting Phase Work
+1. Assign all phase issues to the milestone
+2. Mark as "In Progress" in project board
+3. Work through issues in order
+
+### When Completing an Issue
+1. Create PR (linked to issue)
+2. Merge to main
+3. Close issue
+4. Milestone auto-updates progress
+
+### When Phase is Complete
+1. All issues closed
+2. Milestone shows 100%
+3. Move to next phase
+
+---
+
+## Dependency Chain
+
+```
+Phase 3 ✓ (Complete)
+  ↓
+Phase 4 (World exists, now add hazards)
+  ↓
+Phase 5 (Hazards set, add feedback/NPCs)
+  ↓
+Phase 6 (Polish complete, add victory conditions)
+  ↓
+Cleanup (After features ship)
+```
+
+---
+
+## Current Status
+
+| Milestone | Open | Closed | Progress |
+|-----------|------|--------|----------|
+| Phase 3 | 4 | 0 | 0% |
+| Phase 4 | 3 | 0 | 0% |
+| Phase 5 | 4 | 0 | 0% |
+| Phase 6 | 3 | 0 | 0% |
+| Cleanup | 3 | 0 | 0% |
+| **TOTAL** | **17** | **0** | **0%** |
+
+---
+
+## Links
+
+- **Project Board**: https://github.com/users/m3ssana/projects/3
+- **Milestones Page**: https://github.com/m3ssana/swampfire/milestones
+- **Issues**: https://github.com/m3ssana/swampfire/issues
+- **Workflow**: `.kiro/steering/github-issues-workflow.md`

--- a/.kiro/steering/project-board-setup.md
+++ b/.kiro/steering/project-board-setup.md
@@ -1,0 +1,147 @@
+---
+inclusion: manual
+---
+
+# GitHub Projects (Beta) Setup - Swampfire Protocol
+
+**Date**: 2026-03-08
+**Status**: ✅ Created and configured
+
+---
+
+## Project Details
+
+| Property | Value |
+|----------|-------|
+| **Name** | Swampfire Protocol - Phase Tracker |
+| **Type** | GitHub Projects (Beta) - Table View |
+| **URL** | https://github.com/users/m3ssana/projects/3 |
+| **Owner** | m3ssana (personal account) |
+| **Status** | Active |
+
+---
+
+## Issues Imported (17 Total)
+
+### Phase 3 - World Building (4 issues)
+- #2: 3.1 Zone 0 tilemap
+- #3: 3.2 Zone manager + zone transitions
+- #4: 3.3 Zone 1 tilemap
+- #5: 3.4 Remaining zones
+
+### Phase 4 - Storm & Hazards (3 issues)
+- #6: 4.1 Storm phase system
+- #7: 4.2 Hazard game objects
+- #8: 4.3 Wind + environmental effects
+
+### Phase 5 - Feedback & Polish (4 issues)
+- #9: 5.1 XP popup system
+- #10: 5.2 Combo streak system
+- #11: 5.3 Audio overhaul
+- #12: 5.4 NPC system
+
+### Phase 6 - Endgame & Meta (3 issues)
+- #13: 6.1 Launch sequence
+- #14: 6.2 End-of-run share card
+- #15: 6.3 Achievement toasts
+
+### Cleanup (3 issues)
+- #16: Cleanup - Remove unused assets
+- #17: Cleanup - Remove unused game objects
+- #18: Cleanup - Remove @mikewesthad/dungeon dependency
+
+---
+
+## Custom Fields Created
+
+### 1. Status (Single Select)
+Options: Backlog, In Progress, In Review, Done
+- **Backlog**: Not yet started
+- **In Progress**: Currently being worked on
+- **In Review**: PR created, awaiting approval
+- **Done**: Merged to main, issue closed
+
+### 2. Phase (Single Select)
+Options: Phase 3, Phase 4, Phase 5, Phase 6, Cleanup
+- Maps to development phases from TODO.md
+- Helps filter work by phase
+
+### 3. Type (Single Select)
+Options: User Story, Maintenance
+- **User Story**: Feature/enhancement
+- **Maintenance**: Cleanup/refactoring
+
+### 4. Priority (Single Select)
+Options: Critical, High, Medium, Low
+- Helps prioritize work within phase
+- Can be adjusted based on dependencies
+
+---
+
+## How to Use
+
+### View the Project
+```bash
+# Open in browser
+gh project view 3 --owner m3ssana --web
+
+# Or visit directly
+https://github.com/users/m3ssana/projects/3
+```
+
+### Add Item to Project
+When creating a new issue, it can be added to the project from the issue page.
+
+### Update Item Fields
+Click on an issue in the project table to edit its Status, Phase, Type, and Priority fields.
+
+### Filter by Status
+Use the table filters to show:
+- Only items "In Progress"
+- Only items "In Review"
+- Only items in a specific "Phase"
+
+---
+
+## Workflow Integration
+
+**When an agent starts work on issue #X:**
+1. Go to project board
+2. Find issue in table
+3. Set Status → "In Progress"
+4. Set Phase (auto-filled from issue label)
+5. Set Type (auto-filled from issue label)
+
+**When PR is created:**
+1. Set Status → "In Review"
+2. Link PR in issue comments
+
+**When PR is merged to main:**
+1. Set Status → "Done"
+2. Close the issue (per `.kiro/steering/github-issues-workflow.md`)
+
+---
+
+## Migration from Classic Projects
+
+This project **replaces** any classic GitHub Projects that were in use.
+
+✅ **Advantages of new Projects:**
+- Multiple view types (table, board, roadmap)
+- Custom fields with flexible types
+- Better automation capabilities
+- Superior filtering and grouping
+- Modern, actively maintained interface
+
+---
+
+## Next Steps
+
+1. ✅ Project created with all 17 issues
+2. ✅ Custom fields added
+3. ⏭️ Agents begin using project for workflow tracking
+4. ⏭️ Fill in Phase/Type/Priority based on issue labels
+
+---
+
+**Questions?** Refer to `.kiro/steering/github-issues-workflow.md` and `.kiro/steering/agent-instructions.md`

--- a/.kiro/steering/project-reference.md
+++ b/.kiro/steering/project-reference.md
@@ -1,0 +1,143 @@
+---
+inclusion: auto
+---
+
+# Project Reference - Swampfire Protocol
+
+This file provides guidance to Kiro agents when working with code in this repository.
+
+---
+
+## Bug Reports
+
+When a bug is reported:
+
+1. **Create a GitHub issue** — label `type:bug`, include reproduction steps and expected vs actual behavior
+2. **Add a TODO.md item** — place it under the appropriate phase with a `(bug #<issue>)` reference and mark it ⏳
+
+See `.kiro/steering/agent-instructions.md` → "Bug Reporting Pattern" for the full mandatory template.
+
+## Feature Requests
+
+When a new feature is requested:
+
+1. **Update SPEC.md** — add or revise the relevant section to document the feature's design, behavior, and acceptance criteria
+2. **Create a GitHub issue** — label `type:user-story`, write it as a user story with acceptance criteria
+3. **Add a TODO.md item** — place it under the appropriate phase (or create a new phase), reference the issue number, mark it ⏳, and prioritize it relative to existing items
+
+## Project Hygiene Checklist
+
+After completing any feature or bug fix, run through this checklist:
+
+1. **Update TODO.md** — mark completed items, add any follow-up tasks discovered during the work
+2. **Update/close related GitHub issues** — comment with what was done and close if fully resolved
+3. **Verify the build runs without errors** — `npm run build` and check for errors
+4. **Commit all changed files** — don't leave uncommitted work; use a clear commit message referencing the issue number
+
+---
+
+## Commands
+
+```bash
+npm run dev          # Dev server on localhost:8080
+npm run build        # Production build (Terser, Phaser chunk split)
+npm test             # Run all unit tests once
+npm run test:watch   # Unit tests in watch mode
+npm test -- <file>   # Run a single test file, e.g.: npm test -- storm_phase_logic.test.js
+npm run test:e2e     # Playwright E2E tests (requires dev server running)
+npm run test:all     # Unit + E2E sequentially
+```
+
+E2E tests require Playwright browsers: `npx playwright install chromium`
+
+---
+
+## Architecture
+
+### Scene Stack
+
+The game runs six scenes registered in order in `src/main.js`:
+
+```
+Bootloader → Splash → Transition → Game (+ HUD in parallel) → Outro
+```
+
+- **Bootloader** — preloads all assets (5 zone tilemaps, tilesets, spritesheets, audio) and generates procedural textures (`item_pixel`, `workbench_pixel`, `rocket_pixel`, `rain-drop`) before handing off to Splash.
+- **Transition** — the pre-game cinematic that also **seeds the registry** with a fresh game state (`hp=3, xp=0, timeLeft=3600, inventory=[], systemsInstalled=0`, etc.). All game state lives in the registry — resetting the run means re-running Transition.
+- **Game** — the main scene. Owns zone loading, player, camera, XP popups, interact prompt, and the launch cinematic. Launches **HUD** as a parallel scene via `scene.launch("hud")`.
+- **HUD** — owns the countdown timer (decrements `registry.timeLeft` every real second). Communicates with Game exclusively through the Phaser registry.
+- **Outro** — reads final state from the registry to render the death/timeout/victory screen and generate the share card.
+
+### Cross-Scene State: Phaser Registry
+
+All persistent state is stored in the Phaser global registry (`this.registry` / `scene.registry`). No module-level globals. Key registry keys:
+
+| Key | Init | Owned by |
+|-----|------|----------|
+| `hp` | 3 | Game (decrement on hit) |
+| `xp` | 0 | Game objects (increment) |
+| `timeLeft` | 3600 | HUD (decrement each second) |
+| `timerExpired` | false | HUD (set true at zero) |
+| `inventory` | `[]` | Containers/Workbench/Rocket (push/splice) |
+| `systemsInstalled` | 0 | Rocket (increment) |
+| `stormPhase` | 1 | StormManager (set on transition) |
+| `npcQuests` | `{ harvey, maria, dale, reeves: false }` | NPC (set true on completion) |
+| `visitedZones` | `[0]` | Game (push on zone enter) |
+| `hudToast` | — | Game (trigger HUD toast) |
+| `achievementToast` | — | AchievementManager (trigger HUD toast) |
+
+Listen to specific keys only: `registry.events.on('changedata-<key>', cb)`. Clean up in `scene.events.once('shutdown', ...)`.
+
+### Zone System
+
+`src/gameobjects/zone_manager.js` handles all zone I/O.
+
+- 5 zones (0 = Cypress Creek, 1 = US-41, 2 = Collier Pkwy, 3 = Conner Preserve, 4 = LOLHS/SR-54). All tilemaps pre-loaded by Bootloader so transitions are instant.
+- Each zone is a Tiled JSON map with two tile layers (`ground`, `obstacles`) and one object layer. The object layer drives everything: `container`, `workbench`, `rocket`, `npc`, `spawn`, and `exit` (with `targetZone` property) objects are all spawned from it.
+- `ZONES[id].entryPoints` maps `sourceZoneId → {x, y}` pixel coordinates. When entering zone N from zone M, the player materialises at `ZONES[N].entryPoints[M]`.
+- After a zone swap, `ZoneManager` exposes: `containers[]`, `workbench`, `rocket`, `exits[]`, `currentZoneId`.
+
+**Adding a new zone:** add a config entry to `ZONES`, create `public/assets/maps/zoneN.json` (use `scripts/generate-zoneN.js` as a template), add the tileset image, register both in `Bootloader.preload()`.
+
+### Interactable Interface
+
+All world objects the player can activate with **E** implement two methods:
+
+```js
+promptText() → string   // shown in the bottom-center interact prompt
+interact()   → void     // called when E is pressed while in range
+```
+
+Implementors: `SearchableContainer`, `Workbench`, `Rocket`, `NPC`. Game.js maintains a single `this.nearbyInteractable` pointer, updated each frame via proximity check (72 px Euclidean). Rapid E-presses are safe — each class guards its own idempotency.
+
+### Storm & Hazard Systems
+
+`StormPhaseLogic` (`src/gameobjects/storm_phase_logic.js`) is a **pure module** (no Phaser dependency) — safe to import in Vitest tests directly.
+
+- `getPhaseForTimeLeft(seconds)` → 1–4
+- Phase boundaries: 3600–2701 = 1, 2700–1801 = 2, 1800–901 = 3, 900–0 = 4
+- `getWindDrift(phase)` → 0 / 0 / 0.8 / 1.5 px/frame
+
+`StormManager` owns particle emitters (rain, debris), the darkness overlay, and phase-transition effects (toast, flash, shake). It reacts to `registry.stormPhase` changes.
+
+`HazardManager` spawns hazard objects per zone + phase: Rattlesnakes (zones 0/3, always), Looters (zone 1, phase ≥ 2), PowerLines + FloodZones (zone 1, phase ≥ 3). Each hazard has a dual Matter body: inner = damage hitbox, outer sensor = near-miss warning.
+
+### Asset Generation
+
+Tilesets and tilemaps are **generated by scripts**, not hand-authored. Run the relevant script whenever you need to regenerate:
+
+```bash
+node scripts/generate-zone0.js      # → public/assets/maps/zone0.json
+node scripts/generate-swamp-tiles.js # → public/assets/images/swamp-tiles.png
+node scripts/generate-juan-sprite.js # → public/assets/images/player.png
+```
+
+Scripts use ESM (`import`) and pure Node.js (no npm dependencies beyond zlib). Do not edit the output files by hand.
+
+### Testing Constraints
+
+**Never import `src/gameobjects/*.js` or `src/scenes/*.js` directly in Vitest tests.** These files extend Phaser classes, which throws `ReferenceError: Phaser is not defined` in jsdom. Instead:
+
+- Import pure-logic modules (`storm_phase_logic.js`, the `FLOOD_SPEED_MULTIPLIER` constant from `flood_zone.js`, etc.) — these are safe.
+- For everything else, inline the constants or logic under test with a comment: `// inlined from X.js — keep in sync`.
+- Scene-level behaviour is covered by Playwright E2E tests, not unit tests.

--- a/.kiro/steering/project-reference.md
+++ b/.kiro/steering/project-reference.md
@@ -27,10 +27,10 @@ When a new feature is requested:
 
 ## Project Hygiene Checklist
 
-After completing any feature or bug fix, run through this checklist:
+After completing any feature or bug fix, run through this checklist **before opening the PR**:
 
-1. **Update TODO.md** — mark completed items, add any follow-up tasks discovered during the work
-2. **Update/close related GitHub issues** — comment with what was done and close if fully resolved
+1. **Update TODO.md** — mark completed items ✅ with commit hash, add any follow-up tasks discovered during the work. Stage it with the feature files — it ships in the same PR.
+2. **Update/close related GitHub issues** — comment with what was done; close only after a human merges the PR
 3. **Verify the build runs without errors** — `npm run build` and check for errors
 4. **Commit all changed files** — don't leave uncommitted work; use a clear commit message referencing the issue number
 

--- a/TODO.md
+++ b/TODO.md
@@ -245,7 +245,7 @@ Each task is small enough to fit in a single Claude Code session.
 ## Bugs
 
 Bugs are tracked here alongside their GitHub issue. When a bug is reported:
-1. Create a GitHub issue with label `bug` (see `.claude/AGENT_INSTRUCTIONS.md` for the full pattern)
+1. Create a GitHub issue with label `bug` (see `.kiro/steering/agent-instructions.md` for the full pattern)
 2. Add it to this section as ⏳
 3. Fix it, mark ✅ with commit hash, close the issue
 
@@ -367,9 +367,10 @@ Pure HTML/CSS arcade cabinet frame around the game canvas with ad slots. No JS c
 
 ### 9.1 High Priority (P1)
 
-- ⏳ **9.1.1 Lightning system** [#114](https://github.com/m3ssana/swampfire/issues/114)
+- ✅ **9.1.1 Lightning system** [#114](https://github.com/m3ssana/swampfire/issues/114) — PR #140 (8159f50)
   - Phase 2: 20-30s, Phase 3: 10-20s, Phase 4: 5-15s intervals
   - Camera flash, procedural bolt via Graphics, item reveal on strike, thunder shake
+  - `src/gameobjects/lightning_logic.js` pure module + 47 unit tests
 
 - ⏳ **9.1.2 Near-miss feedback** [#93](https://github.com/m3ssana/swampfire/issues/93)
   - 200ms slow-motion (0.5x), green screen-edge pulse, +15 XP, whoosh SFX


### PR DESCRIPTION
Completes the Claude Code -> Kiro migration and records task 9.1.1 as done.

## Changes
- Port `PROJECT_BOARD_SETUP.md`, `MILESTONES.md`, `GITHUB_QUICK_REFERENCE.md` to `.kiro/steering/`
- New `.kiro/steering/project-reference.md` (architecture + commands, ported from root `CLAUDE.md`)
- Update `agent-instructions.md` "Where to Find Info" table to point at the new files
- Mark TODO 9.1.1 Lightning system as complete (PR #140, commit 8159f50) — it was merged but never recorded
- Fix stale `.claude/AGENT_INSTRUCTIONS.md` reference in TODO.md Bugs section

## Tests
No source changes. `npm test` = 442 passed / 12 files (unchanged baseline).